### PR TITLE
fix(app): Fixed dockerization of node_modules

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,6 @@ services:
       - '3000:3000'
     volumes:
       - './api:/app'
-      - 'bundler_data:/usr/local/bundle'
     env_file:
       - './api/.env'
   frontend:
@@ -26,8 +25,3 @@ services:
       - '8000:8000'
     volumes:
       - './frontend:/app'
-      - 'node_module_data:/app/node_modules'
-
-volumes:
-  bundler_data:
-  node_module_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,9 +1,12 @@
 FROM node:8.15-alpine
 
+ENV NODE_PATH=/node_modules
+ENV PATH=$PATH:/node_modules/.bin
+
+COPY package.json .
+
+RUN yarn
+
 RUN mkdir /app
 WORKDIR /app
 
-COPY package.json .
-COPY yarn.lock .
-
-RUN yarn install


### PR DESCRIPTION
In a previous issue (#58), I tried to put node_modules and ruby gems in a docker volume, but turns out it is not required and causes more harm than good, so I am reverting those changes.

Resolves #58