### PR TITLE
Use a more specific bootstrap version in package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
     "proxy": "http://api:3000",
     "private": true,
     "dependencies": {
-        "bootstrap": "3",
+        "bootstrap": "^3.4.1",
         "moment": "^2.22.2",
         "node-sass": "^4.9.3",
         "react": "^16.5.2",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1555,9 +1555,10 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
 
-bootstrap@3:
+bootstrap@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
+  integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
This PR adjusts bootstrap version specified in package.json to be more specific. Since #84 updated the version in yarn.lock, I assume 3.4.1 or more recent is a reasonable choice for us here.