### PR TITLE
[Fix] TAPP-104: Make TAPP work on Windows 10

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -1,3 +1,4 @@
 COMPOSE_PROJECT_NAME=tapp
 POSTGRES_DB=tapp_development
 POSTGRES_USER=tapp
+PGDATA=/tmp


### PR DESCRIPTION
[#104] adds `PGDATA=/tmp` to the file `/api/.env`