### PR TITLE
[Frontend] TAPP-116: create shared file-related functions for components

### DIFF
--- a/frontend/src/lib/fileManager.js
+++ b/frontend/src/lib/fileManager.js
@@ -1,0 +1,81 @@
+export const readFile = (component, loadDataFunc) => {
+    let files = component.files;
+    if (files.length > 0) {
+        const reader = new FileReader();
+        let importFunc = importChoices(files[0].name, loadDataFunc);
+        reader.readAsText(files[0]);
+        reader.onload = event => importFunc(event.target.result);
+    }
+    component.value = '';
+}
+
+export const downloadFile = async (route, loadMessage) => {
+    try {
+        const res = await fetch(route);
+        if (res.status === 200) {
+            const blob = await res.blob();
+            let filename = getFilename(res);
+            if (window.navigator && window.navigator.msSaveOrOpenBlob) {
+                window.navigator.msSaveOrOpenBlob(blob, filename); //special case for Edge & IE
+            }
+            else{
+                let url = URL.createObjectURL(blob),
+                    a = document.createElement('a');
+                a.href = url;
+                a.download = filename;
+                a.target = "_self" ; //required in FF
+                a.style.display = 'none';
+                document.body.appendChild(a); //required in FF
+                a.click();
+                URL.revokeObjectURL(url);
+                document.body.removeChild(a); //required in FF
+            }
+            loadMessage(optSuccess(true, null));
+        } else {
+            const err = await res.json();
+            loadMessage(optSuccess(false, err));
+        }
+    } catch(err){
+        loadMessage(optSuccess(false, err));
+    }
+}
+
+const optSuccess = (success, content) =>{
+    return {
+        'success': success,
+        'content': content
+    }
+}
+
+const getFilename = (res) =>{
+    try{
+        return res.headers.get('Content-Disposition').match(/filename="(.*)"/)[1];
+    } catch(err){
+        return 'Untitled';
+    }
+}
+
+const importChoices = (file, loadDataFunc) =>{
+    switch(getExtension(file)){
+        case '.json':
+            return data =>{
+                try{
+                    loadDataFunc(optSuccess(true, JSON.parse(data)));
+                }catch(err){
+                    loadDataFunc(optSuccess(false, err));
+                }
+            }
+        default:
+            return data =>{
+                loadDataFunc(optSuccess(true, data));
+            }
+    }
+}
+
+const getExtension = (file) => {
+    let extension = file.match(/\.\w+$/g)
+    if(extension.length > 0)
+        return extension[0];
+    else
+        return null;
+}


### PR DESCRIPTION
Please refer to issue #116 for details.

Tested in the following browsers:
- [x] Firefox
- [x] Chrome
- [x] Edge
- [ ] IE  `// needs polyfill for fetch, promise, arrow function`
- [ ] Safari

As a starter, a file called `fileManager.js` is made for action involving files, such as:
 - `readFile`: a function that takes an input file and reads it as either text or JSON
 - `downloadFile`: a function that fetches a blob given at a certain route and triggers a download file response

Note: both of these functions output a JSON, using the second function argument, with the following format:
```
{
  success: boolean,
  content: string OR JSON, // content of file OR error message
}
```
Furthermore, both functions takes in a function as the second parameter. The function is assumed to take in only one argument. This single argument should be the aforementioned JSON.

Here is an example on the use of `readFile()` in HTML:
```
<input type='file' onchange='readFile(this, console.log)' />
```
Please note that the use of `onchange` is very important for getting the content of the file when you click on the upload button.

Here is an example on the use of `downloadFile()` in HTML:
```
<button onclick='downloadFile("https://www.wikipedia.org/portal/wikipedia.org/assets/img/sprite-556af1a5.svg", console.log)'>Download</button>
```
For a quick test of these functions, you can make a HTML like this:
```
<!DOCTYPE html>
<html>
<head>
	<script type="text/javascript" src="./fileManager.js"></script>
</head>
<body>
	<p>Upload Test</p>
	<input type='file' onchange='readFile(this, console.log)' />
	<button onclick='downloadFile("https://www.wikipedia.org/portal/wikipedia.org/assets/img/sprite-556af1a5.svg", console.log)'>Download</button>
</body>
</html>
```
Note: You will need to put this file into `/frontend/src/lib/` for it to test it on your browser. You will also need to comment out the `export` before the functions in `fileManager.js` because it's an independent JS file. 