### PR TITLE
feat(app): added deployment script for production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 tmp
 .idea
+public
+.env

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ local machine for development and testing purposes. Currently, the entire app
 ### Prerequisties
 
 1. [Docker](https://docs.docker.com/install/#supported-platforms)
-2. [Docker Compose](https://docs.docker.com/compose/install/) (Must be installed seperately on Linux)*
+2. [Docker Compose](https://docs.docker.com/compose/install/) (Must be installed seperately on Linux)
 3. Ruby, only if you would like to use the precommit hook
 
 * If you are running OSx or Windows, your Docker installation will have come with docker-compose.
@@ -125,40 +125,43 @@ The app is organized into three entities:
 
 ### Running the app with Docker
 
-To begin, make sure that Docker is running on your system. Once it is, begin by building all the relevant docker images by invoking
+#### Overview
+We have three docker compose files that are important to know:
+1. `docker-compose.yml` is our base docker-compose file. This by itself will
+   build the db and the API
+2. `docker-compose.dev.yml` is our development docker-compose file. This will
+   build the front end.
+3. `docker-compose.prod.yml` is our production docker-compose file. This will
+   also build the db and API, but not the front end
+
+To begin, make sure that Docker is running on your system. Begin by invoking:
 
 ```
-docker-compose build
+chmod u+x ./start_local.sh
+./start_local.sh
 ```
+This script will build the front end, database and api by combining the base
+file and development
 
-then invoke
-
-```
-docker-compose up
-```
-
-This will spin up three services: one for the database, one for api and one for the frontend.
-
-You can access the rails app from your browser by navigating to `http://localhost:3000`.
+You can access the rails app from your browser by navigating to
+`http://localhost:3000`.
 
 You will be able to access the frontend at `http://localhost:8000`. Note that
-unlike most traditional rails app, under our project, rails does not serve views.
-It only provides the API which the frontend, served seperately by yarn, pulls from.
-
-In the future, you can collapse these two commands into one with:
-
-```
-docker-compose up --build
-```
+unlike most traditional rails app, under our project, rails does not serve
+views.  It only provides the API which the frontend, served seperately by yarn,
+pulls from.
 
 To view the STDOUT from a docker container of a running server, you can invoke
 
 ```docker-compose logs -tf <image>```
 
+To stop everything, use `docker-compose down`.
+
 ### Navigating into the containers from the command line
 
-Currently, we define three services under docker-compose: frontend, tapp and db. If you would
-like to interact with any of the containers from the command line, you can do so by invoking:
+Currently, we define three services under docker-compose: frontend, tapp and
+db. If you would like to interact with any of the containers from the command
+line, you can do so by invoking:
 
 ```
 docker-compose exec [service] sh
@@ -255,3 +258,9 @@ scratch and `rake db:migrate`.
 After `running docker-compose up`, you may see a message that reads `A server is already running. Check /app/tmp/pids/server.pid.`. The api container will fail. 
 
 To resolve this issue, halt the docker-compose command (killing the other containers) with cmd-c/ctrl-c, and delete the file located under the project route at `api/tmp/pids/server.pid`. You will be able to relaunch the server without issues. This issue normally arises when you kill the running instance of the project without alloting time for a proper teardown.
+
+2. Docker cannot start up a front-end service, complaining that it can't find an image.
+
+You can resolve this by using `docker containers ls -a`, finding all
+deactivated containers, and then removing them with `docker container rm
+[container ID]`. Then, you should be able to run `./start_local.sh`

--- a/api/.env
+++ b/api/.env
@@ -1,4 +1,0 @@
-COMPOSE_PROJECT_NAME=tapp
-POSTGRES_DB=tapp_development
-POSTGRES_USER=tapp
-PGDATA=/tmp

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,0 +1,1 @@
+master.key

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -13,3 +13,4 @@ COPY Gemfile Gemfile.lock ./
 
 RUN bundle install
 
+COPY . ./

--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -4,4 +4,8 @@
 class ApplicationController < ActionController::Base
   include Response
   include ExceptionHandler
+
+  def index
+    render :file => 'public/index.html'
+  end  
 end

--- a/api/config/database.yml
+++ b/api/config/database.yml
@@ -11,11 +11,12 @@ default: &default
   host: db
   encoding: unicode
   pool: 5
+  user: <%= ENV.fetch("POSTGRES_USER") %>
+  password: <%= ENV.fetch("POSTGRES_PASSWORD") %>
 
 development:
   <<: *default
-  database: <%= ENV['POSTGRES_DB'] %>
-  user: <%= ENV['POSTGRES_USER'] %>
+  database: <%= ENV.fetch("POSTGRES_DB") %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -23,9 +24,8 @@ development:
 test:
   <<: *default
   database: tapp_test
-  user: tapp
 
 production:
   <<: *default
-  database: tapp_production
-  user: tapp
+  database: <%= ENV.fetch("POSTGRES_DB") %>
+

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -2,6 +2,9 @@
 
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  root :to => 'application#index'
+
   namespace :api do
     namespace :v1 do
       resources :positions, :instructors, except: [:new, :edit]
@@ -11,5 +14,9 @@ Rails.application.routes.draw do
 
       match 'positions/import' => 'positions#import', :via => :post
     end
+  end
+
+  get '*path', to: "application#index", constraints: ->(request) do
+        !request.xhr? && request.format.html?
   end
 end

--- a/api/credentials.yml
+++ b/api/credentials.yml
@@ -1,0 +1,6 @@
+# aws:
+#   access_key_id: 123
+#   secret_access_key: 345
+
+# Used as the base secret for all MessageVerifiers in Rails, including the one protecting cookies.
+secret_key_base: 5dd936603469858c82acbdc979497918584be11fb6b8d9ae83cc5f507dbbe1e99869b6b50db8f2267210592608febc1e1d088843d24ba9cb8dd16499dd2fe2d8

--- a/api/docker-entrypoint.sh
+++ b/api/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+bundle exec rails db:migrate
+
+if [[ $? != 0 ]]; then
+  echo
+  echo "== Failed to migrate. Running setup first."
+  echo
+  bundle exec rails db:setup
+fi
+
+# Execute the given or default command:
+exec "$@"

--- a/api/public/robots.txt
+++ b/api/public/robots.txt
@@ -1,1 +1,0 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file

--- a/deploy
+++ b/deploy
@@ -4,4 +4,3 @@ docker-compose -f docker-compose.yml -f docker-compose.prod.yml down --remove-or
 docker-compose -f docker-compose.frontend.yml up --build --force-recreate
 cp -a frontend/build/. api/public/
 docker-compose -f docker-compose.yml -f docker-compose.prod.yml up --build --force-recreate -d
-docker-compose exec api sh -c "rails db:migrate RAILS_ENV=production"

--- a/deploy
+++ b/deploy
@@ -1,0 +1,7 @@
+#!/bin/bash
+cp prod.env .env 
+docker-compose -f docker-compose.yml -f docker-compose.prod.yml down --remove-orphans
+docker-compose -f docker-compose.frontend.yml up --build --force-recreate
+cp -a frontend/build/. api/public/
+docker-compose -f docker-compose.yml -f docker-compose.prod.yml up --build --force-recreate -d
+docker-compose exec api sh -c "rails db:migrate RAILS_ENV=production"

--- a/dev.env
+++ b/dev.env
@@ -1,0 +1,12 @@
+# docker compose environment variables for production 
+COMPOSE_PROJECT_NAME=tapp
+
+# environment
+RAILS_ENV=development
+
+# database config
+POSTGRES_DB=tapp_development
+POSTGRES_USER=tapp
+POSTGRES_PASSWORD=mysecretpassword
+SECRET_KEY_BASE=+IAvCfOt+ETpeEc92ChgRITzV4yqLxmaXZrmtCh33lpHZmxnVXymRJ70iKq5FZeBrVLVNSfwlcMswe2YCZc8D/UfRM6Xf+TYjX7di1wQvG9lJN1FNR3MZ8g8re0CE65NHtX9s+lKIBJOndt2A4HyqAhaOaJGq4jPK7A+NwVJk4/YgwQKia8jkEvxuPYkA2U+s1AnfWkMpoUwOHdvHothE1qL++tIGcMs/iizC2fi0asOvGPPJ2Bh36wuhTuXpayqXzGQ57Bt2yyGVgLwaS+G7N8tYRlrXktMb9UgcZ39wJXhBJW5jcqcpPyTf05jWBnwE8l1a+bWYtunMO53EnKoPx/2UP2sp7tm0ToDaJLiQs20P63B2AJ24qhVEYyE7xLAXhmZCxPjeQeT5fqX/Qk1k32ATD6us/6rmE6F--Ly1nCExrFLhZ1y9Q--McmU0GTPJS5b3sfNQOnWnA==
+

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,16 @@
+version: '3'
+
+services:
+  frontend:
+    command: yarn start
+    build: ./frontend
+    ports:
+      - '8000:8000'
+    volumes:
+      - './frontend:/app'
+  api:
+    volumes:
+      - './api:/app'
+  db:
+    volumes:
+      - './tmp/db:/var/lib/postgresql/data'

--- a/docker-compose.frontend.yml
+++ b/docker-compose.frontend.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  frontend:
+    command: yarn build
+    build: ./frontend
+    volumes:
+      - './frontend:/app'

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+  api:
+    restart: always
+  db:
+    restart: always
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,10 @@ version: '3'
 services:
   db:
     image: 'postgres:10.5-alpine'
-    volumes:
-      - './tmp/db:/var/lib/postgresql/data'
-    env_file:
-      - './api/.env'
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
   api:
     depends_on:
       - 'db'
@@ -14,14 +14,12 @@ services:
     build: ./api
     ports:
       - '3000:3000'
-    volumes:
-      - './api:/app'
-    env_file:
-      - './api/.env'
-  frontend:
-    command: yarn start
-    build: ./frontend
-    ports:
-      - '8000:8000'
-    volumes:
-      - './frontend:/app'
+    environment:
+      RAILS_ENV: ${RAILS_ENV}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+      RAILS_SERVE_STATIC_FILES: ${RAILS_SERVE_STATIC_FILES}
+      RAILS_LOG_TO_STDOUT: ${RAILS_LOG_TO_STDOUT}
+

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,4 +9,3 @@ RUN yarn
 
 RUN mkdir /app
 WORKDIR /app
-

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,8 @@
         "start": "PORT=8000 react-scripts start",
         "build": "react-scripts build",
         "test": "react-scripts test",
-        "eject": "react-scripts eject"
+        "eject": "react-scripts eject",
+        "deploy": "cp -a build/. ../api/public/"
     },
     "eslintConfig": {
         "extends": "react-app"

--- a/prod.env
+++ b/prod.env
@@ -1,0 +1,14 @@
+# docker compose environment variables for production 
+COMPOSE_PROJECT_NAME=tapp
+
+# environment
+RAILS_ENV=production
+RAILS_SERVE_STATIC_FILES=1
+RAILS_LOG_TO_STDOUT=1
+
+# database config
+POSTGRES_DB=tapp_production
+POSTGRES_USER=tapp
+POSTGRES_PASSWORD=mysecretpassword
+SECRET_KEY_BASE=+IAvCfOt+ETpeEc92ChgRITzV4yqLxmaXZrmtCh33lpHZmxnVXymRJ70iKq5FZeBrVLVNSfwlcMswe2YCZc8D/UfRM6Xf+TYjX7di1wQvG9lJN1FNR3MZ8g8re0CE65NHtX9s+lKIBJOndt2A4HyqAhaOaJGq4jPK7A+NwVJk4/YgwQKia8jkEvxuPYkA2U+s1AnfWkMpoUwOHdvHothE1qL++tIGcMs/iizC2fi0asOvGPPJ2Bh36wuhTuXpayqXzGQ57Bt2yyGVgLwaS+G7N8tYRlrXktMb9UgcZ39wJXhBJW5jcqcpPyTf05jWBnwE8l1a+bWYtunMO53EnKoPx/2UP2sp7tm0ToDaJLiQs20P63B2AJ24qhVEYyE7xLAXhmZCxPjeQeT5fqX/Qk1k32ATD6us/6rmE6F--Ly1nCExrFLhZ1y9Q--McmU0GTPJS5b3sfNQOnWnA==
+

--- a/start_dev
+++ b/start_dev
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml down
+cp dev.env .env 
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+docker-compose exec api sh -c "rails db:migrate RAILS_ENV=development"
+

--- a/start_dev
+++ b/start_dev
@@ -1,7 +1,7 @@
 #!/bin/bash
-
 docker-compose -f docker-compose.yml -f docker-compose.dev.yml down
 cp dev.env .env 
+echo 'Please go to localhost:8000 for frontend' > ./api/public/index.html
 docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --build
-docker-compose exec api sh -c "rails db:migrate RAILS_ENV=development"
+
 


### PR DESCRIPTION
This commit makes several changes to the docker setup to create a deployment process for production.  The docker compose files are now split into four files:
	- docker-compose.yml: defines the api and db services
	- docker-compose.dev.yml: defines development specific docker behaviour
	- docker-compose.prod.yml: defines production specific docker behaviour
	- docker-compose.frontend.yml: defines a container used only to build optimized webpack bundles

Environment variables for rails and postgres can be found in prod.env and dev.env.

To deploy, pull the most recent master branch into the server and run the deploy script.  This will spin up the rails and postgres containers in detached mode.
To run the app locally, run the start_dev script.  This will spin up a rails, webpack, and postgres server in development mode with hot-reloading enabled.