### PR TITLE
[Fix] TAPP-118: Refactoring hard coded seed data loading into using JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ rake db:setup
 ```
 
 This will create your local database, run all migrations and populate the DB 
-with seed data. 
+with seed data. Note that seed data is loaded from `api/db/seed/` folder where
+each json file represents a table.
 
 Once your DB is setup, you can gain SQL access to it by first navigating into 
 the DB container, then invoking:

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_17_031525) do
+ActiveRecord::Schema.define(version: 2019_05_22_123015) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,22 @@ ActiveRecord::Schema.define(version: 2019_05_17_031525) do
     t.index ["applicant_id", "position_id"], name: "index_assignments_on_applicant_id_and_position_id", unique: true
     t.index ["applicant_id"], name: "index_assignments_on_applicant_id"
     t.index ["position_id"], name: "index_assignments_on_position_id"
+  end
+
+  create_table "funding_sources", force: :cascade do |t|
+    t.bigint "assignment_id"
+    t.bigint "position_id"
+    t.bigint "offer_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.float "hours"
+    t.date "start_date"
+    t.date "end_date"
+    t.integer "ddah_type"
+    t.float "rates"
+    t.index ["assignment_id"], name: "index_funding_sources_on_assignment_id"
+    t.index ["offer_id"], name: "index_funding_sources_on_offer_id"
+    t.index ["position_id"], name: "index_funding_sources_on_position_id"
   end
 
   create_table "instructors", force: :cascade do |t|

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -52,22 +52,6 @@ ActiveRecord::Schema.define(version: 2019_05_24_054519) do
     t.index ["position_id"], name: "index_assignments_on_position_id"
   end
 
-  create_table "funding_sources", force: :cascade do |t|
-    t.bigint "assignment_id"
-    t.bigint "position_id"
-    t.bigint "offer_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.float "hours"
-    t.date "start_date"
-    t.date "end_date"
-    t.integer "ddah_type"
-    t.float "rates"
-    t.index ["assignment_id"], name: "index_funding_sources_on_assignment_id"
-    t.index ["offer_id"], name: "index_funding_sources_on_offer_id"
-    t.index ["position_id"], name: "index_funding_sources_on_position_id"
-  end
-
   create_table "instructors", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/api/db/seed/applicant.json
+++ b/api/db/seed/applicant.json
@@ -1,0 +1,30 @@
+{
+    "applicants": [
+        {
+            "first_name": "George",
+            "last_name": "Wu",
+            "utorid": "wugeorge",
+            "student_number": "1000136937",
+            "email": "georgewu.sample@mail.utoronto.ca",
+            "phone": "6473879674",
+            "address": "130 St. George Street",
+            "dept": "Computer Science",
+            "year_in_program": 4,
+            "is_grad_student": false,
+            "is_full_time": true
+        },
+        {
+            "first_name": "Alice",
+            "last_name": "Chen",
+            "utorid": "alice88",
+            "student_number": "1000222222",
+            "email": "alice.sample@mail.utoronto.ca",
+            "phone": "6473877777",
+            "address": "130 St. George Street",
+            "dept": "Computer Science",
+            "year_in_program": 3,
+            "is_grad_student": false,
+            "is_full_time": true
+        }
+    ]
+}

--- a/api/db/seed/applicant.json
+++ b/api/db/seed/applicant.json
@@ -1,5 +1,5 @@
 {
-    "applicants": [
+    "applicant": [
         {
             "first_name": "George",
             "last_name": "Wu",

--- a/api/db/seed/instructor.json
+++ b/api/db/seed/instructor.json
@@ -1,0 +1,16 @@
+{
+    "instructor": [
+        {
+            "first_name": "Paul",
+            "last_name": "Brown",
+            "email": "paul.brown.sample@utoronto.ca",
+            "utorid": "brownpau"
+        },
+        {
+            "first_name": "David",
+            "last_name": "Horton",
+            "email": "david.horton.sample@utoronto.ca",
+            "utorid": "dividhor"
+        }
+    ]
+}

--- a/api/db/seed/instructor.json
+++ b/api/db/seed/instructor.json
@@ -4,13 +4,15 @@
             "first_name": "Paul",
             "last_name": "Brown",
             "email": "paul.brown.sample@utoronto.ca",
-            "utorid": "brownpau"
+            "utorid": "brownpau",
+            "position_index": [0, 1]
         },
         {
             "first_name": "David",
             "last_name": "Horton",
             "email": "david.horton.sample@utoronto.ca",
-            "utorid": "dividhor"
+            "utorid": "dividhor",
+            "position_index": [0]
         }
     ]
 }

--- a/api/db/seed/position.json
+++ b/api/db/seed/position.json
@@ -1,0 +1,30 @@
+{
+    "position": [
+        {
+            "course_code": "CSC148H1F",
+            "course_name": "Introduction to Computer Science",
+            "current_enrolment": 500,
+            "duties": "Lead labs",
+            "qualifications": "Well versed in Python",
+            "hours": 54,
+            "cap_enrolment": 500,
+            "num_waitlisted": 100,
+            "start_date": "2018-9-10",
+            "end_date": "2018-12-10",
+            "openings": 40
+        },
+        {
+            "course_code": "CSC369H1W",
+            "course_name": "Operating System",
+            "current_enrolment": 200,
+            "duties": "Lead labs",
+            "qualifications": "Well versed in Operating System",
+            "hours": 54,
+            "cap_enrolment": 200,
+            "num_waitlisted": 50,
+            "start_date": "2019-01-01",
+            "end_date": "2018-04-30",
+            "openings": 20
+        }
+    ]
+}

--- a/api/db/seed/position.json
+++ b/api/db/seed/position.json
@@ -11,7 +11,8 @@
             "num_waitlisted": 100,
             "start_date": "2018-9-10",
             "end_date": "2018-12-10",
-            "openings": 40
+            "openings": 40,
+            "session_index": 0
         },
         {
             "course_code": "CSC369H1W",
@@ -24,7 +25,8 @@
             "num_waitlisted": 50,
             "start_date": "2019-01-01",
             "end_date": "2018-04-30",
-            "openings": 20
+            "openings": 20,
+            "session_index": 1
         }
     ]
 }

--- a/api/db/seed/preference.json
+++ b/api/db/seed/preference.json
@@ -1,0 +1,14 @@
+{
+    "preference": [
+        {   
+            "applicant_index": 0,
+            "position_index": 0,
+            "priority": 1
+        },
+        {
+            "applicant_index": 1,
+            "position_index": 1,
+            "priority": 0
+        }
+    ]
+}

--- a/api/db/seed/session.json
+++ b/api/db/seed/session.json
@@ -1,0 +1,18 @@
+{
+    "session": [
+        {
+            "year": 2018,
+            "semester": "fall",
+            "pay": 42.25,
+            "start_date": "2018-09-01",
+            "end_date": "2018-12-31" 
+        },
+        {
+            "year": 2019,
+            "semester": "winter",
+            "pay": 43,
+            "start_date": "2019-01-01",
+            "end_date": "2019-04-30" 
+        }
+    ]
+}

--- a/api/db/seed/session.json
+++ b/api/db/seed/session.json
@@ -1,6 +1,6 @@
 {
     "session": [
-        {
+        {   
             "year": 2018,
             "semester": "fall",
             "pay": 42.25,

--- a/api/db/seeds.rb
+++ b/api/db/seeds.rb
@@ -1,69 +1,8 @@
 # frozen_string_literal: true
 
-# This file should contain all the record creation needed to seed the database with its default
-# values. The data can then be loaded with the rails db:seed command (or created alongside the
-# database with db:setup).
-
-
-# a = Applicant.create(
-#   first_name: 'George',
-#   last_name: 'Wu',
-#   utorid: 'wugeorge',
-#   student_number: '1000136937',
-#   email: 'george.wu.sample@mail.utoronto.ca',
-#   phone: '6473879674',
-#   address: '130 St. George Street',
-#   dept: 'Computer Science',
-#   year_in_program: 4,
-#   is_grad_student: false,
-#   is_full_time: true
-# )
-# s = Session.create(
-#   year: 2018,
-#   semester: 'fall',
-#   pay: 42.25,
-#   start_date: DateTime.new(2018, 9, 1),
-#   end_date: DateTime.new(2018, 12, 31),
-# )
-# p = Position.create(
-#   session: s, # session is a ruby obj ref
-#   course_code: 'CSC148H1F',
-#   course_name: 'Introduction to Computer Science',
-#   current_enrolment: 500,
-#   duties: 'Lead labs',
-#   qualifications: 'Well versed in Python',
-#   hours: 54,
-#   cap_enrolment: 500,
-#   num_waitlisted: 100,
-#   start_date: DateTime.new(2018, 9, 10),
-#   end_date: DateTime.new(2018, 12, 10),
-#   openings: 40
-# )
-
-# # perference is assembled by ref
-# Preference.create(
-#   position: p,
-#   applicant: a,
-#   priority: 1
-# )
-# i = Instructor.create(
-#   first_name: 'Paul',
-#   last_name: 'Brown',
-#   email: 'paul.brown.sample@utoronto.ca',
-#   utorid: 'brownpau'
-# )
-
-# p.instructors << i
-
-# user1 = User.create(
-#   utorid: 'brownpau',
-#   role: 'instructor'
-# )
-
-# user2 = User.create(
-#   utorid: 'admintes',
-#   role: 'admin'
-# )
+# Seed data is contained in the json files under seed folder. This file serves as the script of 
+# pasing json file and create tables from the parsed data. The data can then be loaded with the rails db:seed command (or created alongside the
+# database with db:setup). For testing purpose, use db:reset to reload all the table.
 
 seed_data_dir = Rails.root.join('db', 'seed')
 
@@ -119,5 +58,10 @@ instructors = json_data.map do |row|
   end
 end
 
-
-puts applicants
+# users
+data = File.read("#{seed_data_dir}/user.json")
+raise JSON::ParserError.new("the source file is empty") if data.strip.length == 0
+json_data = JSON.parse(data).fetch("user")
+users = json_data.map do |row|
+  User.create!(row.with_indifferent_access)
+end

--- a/api/db/seeds.rb
+++ b/api/db/seeds.rb
@@ -4,65 +4,120 @@
 # values. The data can then be loaded with the rails db:seed command (or created alongside the
 # database with db:setup).
 
-a = Applicant.create(
-  first_name: 'George',
-  last_name: 'Wu',
-  utorid: 'wugeorge',
-  student_number: '1000136937',
-  email: 'george.wu.sample@mail.utoronto.ca',
-  phone: '6473879674',
-  address: '130 St. George Street',
-  dept: 'Computer Science',
-  year_in_program: 4,
-  is_grad_student: false,
-  is_full_time: true
-)
-s = Session.create(
-  year: 2018,
-  semester: 'fall',
-  pay: 42.25,
-  start_date: DateTime.new(2018, 9, 1),
-  end_date: DateTime.new(2018, 12, 31),
-)
-p = Position.create(
-  session: s, # session is a ruby obj ref
-  course_code: 'CSC148H1F',
-  course_name: 'Introduction to Computer Science',
-  current_enrolment: 500,
-  duties: 'Lead labs',
-  qualifications: 'Well versed in Python',
-  hours: 54,
-  cap_enrolment: 500,
-  num_waitlisted: 100,
-  start_date: DateTime.new(2018, 9, 10),
-  end_date: DateTime.new(2018, 12, 10),
-  openings: 40
-)
 
-# perference is assembled by ref
-Preference.create(
-  position: p,
-  applicant: a,
-  priority: 1
-)
-i = Instructor.create(
-  first_name: 'Paul',
-  last_name: 'Brown',
-  email: 'paul.brown.sample@utoronto.ca',
-  utorid: 'brownpau'
-)
+# a = Applicant.create(
+#   first_name: 'George',
+#   last_name: 'Wu',
+#   utorid: 'wugeorge',
+#   student_number: '1000136937',
+#   email: 'george.wu.sample@mail.utoronto.ca',
+#   phone: '6473879674',
+#   address: '130 St. George Street',
+#   dept: 'Computer Science',
+#   year_in_program: 4,
+#   is_grad_student: false,
+#   is_full_time: true
+# )
+# s = Session.create(
+#   year: 2018,
+#   semester: 'fall',
+#   pay: 42.25,
+#   start_date: DateTime.new(2018, 9, 1),
+#   end_date: DateTime.new(2018, 12, 31),
+# )
+# p = Position.create(
+#   session: s, # session is a ruby obj ref
+#   course_code: 'CSC148H1F',
+#   course_name: 'Introduction to Computer Science',
+#   current_enrolment: 500,
+#   duties: 'Lead labs',
+#   qualifications: 'Well versed in Python',
+#   hours: 54,
+#   cap_enrolment: 500,
+#   num_waitlisted: 100,
+#   start_date: DateTime.new(2018, 9, 10),
+#   end_date: DateTime.new(2018, 12, 10),
+#   openings: 40
+# )
 
-p.instructors << i
+# # perference is assembled by ref
+# Preference.create(
+#   position: p,
+#   applicant: a,
+#   priority: 1
+# )
+# i = Instructor.create(
+#   first_name: 'Paul',
+#   last_name: 'Brown',
+#   email: 'paul.brown.sample@utoronto.ca',
+#   utorid: 'brownpau'
+# )
 
-user1 = User.create(
-  utorid: 'brownpau',
-  role: 'instructor'
-)
+# p.instructors << i
 
-user2 = User.create(
-  utorid: 'admintes',
-  role: 'admin'
-)
+# user1 = User.create(
+#   utorid: 'brownpau',
+#   role: 'instructor'
+# )
 
-tables = ['applicant', 'session', 'position', 'preference', 'instructor']
+# user2 = User.create(
+#   utorid: 'admintes',
+#   role: 'admin'
+# )
+
 seed_data_dir = Rails.root.join('db', 'seed')
+
+# applicants
+data = File.read("#{seed_data_dir}/applicant.json")
+raise JSON::ParserError.new("the source file is empty") if data.strip.length == 0
+json_data = JSON.parse(data).fetch("applicant")
+applicants = json_data.map do |row|
+  Applicant.create!(row.with_indifferent_access)
+end
+
+# sessions
+data = File.read("#{seed_data_dir}/session.json")
+raise JSON::ParserError.new("the source file is empty") if data.strip.length == 0
+json_data = JSON.parse(data).fetch("session")
+sessions = json_data.map do |row|
+  Session.create!(row.with_indifferent_access)
+end
+
+# positions
+data = File.read("#{seed_data_dir}/position.json")
+raise JSON::ParserError.new("the source file is empty") if data.strip.length == 0
+json_data = JSON.parse(data).fetch("position")
+positions = json_data.map do |row|
+  s = sessions[row["session_index"]]
+  row = row.except("session_index").merge(session: s)
+  Position.create!(row.with_indifferent_access)
+end
+
+# preference
+data = File.read("#{seed_data_dir}/preference.json")
+raise JSON::ParserError.new("the source file is empty") if data.strip.length == 0
+json_data = JSON.parse(data).fetch("preference")
+preference = json_data.map do |row|
+  a = applicants[row["applicant_index"]]
+  p = positions[row["position_index"]]
+  row = row.except("applicant_index").merge(applicant: a)
+  row = row.except("position_index").merge(position: p)
+  Preference.create!(row.with_indifferent_access)
+end
+
+# instructors
+data = File.read("#{seed_data_dir}/instructor.json")
+raise JSON::ParserError.new("the source file is empty") if data.strip.length == 0
+json_data = JSON.parse(data).fetch("instructor")
+instructors = json_data.map do |row|
+  position_indexes = row["position_index"]
+  row = row.except("position_index")
+  i = Instructor.create!(row.with_indifferent_access)
+  position_indexes.each do |p|
+    i.positions << positions[p]
+    i.save
+  end
+end
+
+
+puts applicants

--- a/api/db/seeds.rb
+++ b/api/db/seeds.rb
@@ -25,7 +25,7 @@ s = Session.create(
   end_date: DateTime.new(2018, 12, 31),
 )
 p = Position.create(
-  session: s,
+  session: s, # session is a ruby obj ref
   course_code: 'CSC148H1F',
   course_name: 'Introduction to Computer Science',
   current_enrolment: 500,
@@ -38,6 +38,8 @@ p = Position.create(
   end_date: DateTime.new(2018, 12, 10),
   openings: 40
 )
+
+# perference is assembled by ref
 Preference.create(
   position: p,
   applicant: a,
@@ -61,3 +63,6 @@ user2 = User.create(
   utorid: 'admintes',
   role: 'admin'
 )
+
+tables = ['applicant', 'session', 'position', 'preference', 'instructor']
+seed_data_dir = Rails.root.join('db', 'seed')


### PR DESCRIPTION
Please refer to issue #118 

- Removed hardcoded `create table` in `seed.rb`
- Represent seed data in JSON form under folder `seed`
- Tables have dependencies, which means the order of creating tables is somehow fixed. That's part of the reason for the boilerplate code (the re-occurring section of parsing JSON and create table)