### PR TITLE
[frontend] Add a dashboard and a local state selector

### DIFF
--- a/frontend/src/api/actions/applicants.js
+++ b/frontend/src/api/actions/applicants.js
@@ -12,6 +12,8 @@ import {
     validatedApiDispatcher
 } from "./utils";
 import { apiGET, apiPOST } from "../../libs/apiUtils";
+import { applicantsReducer } from "../reducers/applicants";
+import { createSelector } from "reselect";
 
 // actions
 const fetchApplicantsSuccess = actionFactory(FETCH_APPLICANTS_SUCCESS);
@@ -76,7 +78,16 @@ export const deleteApplicant = validatedApiDispatcher({
 });
 
 // selectors
-export const applicantsSelector = state => state._modelData;
+
+// Each reducer is given an isolated state; instead of needed to remember to
+// pass the isolated state to each selector, `reducer._localStoreSelector` will intelligently
+// search for and return the isolated state associated with `reducer`. This is not
+// a standard redux function.
+export const localStoreSelector = applicantsReducer._localStoreSelector;
+export const applicantsSelector = createSelector(
+    localStoreSelector,
+    state => state._modelData
+);
 
 // Any time the active session changes, we want to refetch
 // all data. Calling `runOnActiveSessionChange` ensures that

--- a/frontend/src/api/actions/applications.js
+++ b/frontend/src/api/actions/applications.js
@@ -12,6 +12,8 @@ import {
     validatedApiDispatcher
 } from "./utils";
 import { apiGET, apiPOST } from "../../libs/apiUtils";
+import { applicationsReducer } from "../reducers/applications";
+import { createSelector } from "reselect";
 
 // actions
 const fetchApplicationsSuccess = actionFactory(FETCH_APPLICATIONS_SUCCESS);
@@ -80,7 +82,16 @@ export const deleteApplication = validatedApiDispatcher({
 });
 
 // selectors
-export const applicationsSelector = state => state._modelData;
+
+// Each reducer is given an isolated state; instead of needed to remember to
+// pass the isolated state to each selector, `reducer._localStoreSelector` will intelligently
+// search for and return the isolated state associated with `reducer`. This is not
+// a standard redux function.
+export const localStoreSelector = applicationsReducer._localStoreSelector;
+export const applicationsSelector = createSelector(
+    localStoreSelector,
+    state => state._modelData
+);
 
 // Any time the active session changes, we want to refetch
 // all data. Calling `runOnActiveSessionChange` ensures that

--- a/frontend/src/api/actions/assignments.js
+++ b/frontend/src/api/actions/assignments.js
@@ -12,6 +12,8 @@ import {
     validatedApiDispatcher
 } from "./utils";
 import { apiGET, apiPOST } from "../../libs/apiUtils";
+import { assignmentsReducer } from "../reducers/assignments";
+import { createSelector } from "reselect";
 
 // actions
 const fetchAssignmentsSuccess = actionFactory(FETCH_ASSIGNMENTS_SUCCESS);
@@ -76,7 +78,16 @@ export const deleteAssignment = validatedApiDispatcher({
 });
 
 // selectors
-export const assignmentsSelector = state => state._modelData;
+
+// Each reducer is given an isolated state; instead of needed to remember to
+// pass the isolated state to each selector, `reducer._localStoreSelector` will intelligently
+// search for and return the isolated state associated with `reducer`. This is not
+// a standard redux function.
+export const localStoreSelector = assignmentsReducer._localStoreSelector;
+export const assignmentsSelector = createSelector(
+    localStoreSelector,
+    state => state._modelData
+);
 
 // Any time the active session changes, we want to refetch
 // all data. Calling `runOnActiveSessionChange` ensures that

--- a/frontend/src/api/actions/instructors.js
+++ b/frontend/src/api/actions/instructors.js
@@ -12,6 +12,8 @@ import {
     validatedApiDispatcher
 } from "./utils";
 import { apiGET, apiPOST } from "../../libs/apiUtils";
+import { instructorsReducer } from "../reducers/instructors";
+import { createSelector } from "reselect";
 
 // actions
 const fetchInstructorsSuccess = actionFactory(FETCH_INSTRUCTORS_SUCCESS);
@@ -76,7 +78,16 @@ export const deleteInstructor = validatedApiDispatcher({
 });
 
 // selectors
-export const instructorsSelector = state => state._modelData;
+
+// Each reducer is given an isolated state; instead of needed to remember to
+// pass the isolated state to each selector, `reducer._localStoreSelector` will intelligently
+// search for and return the isolated state associated with `reducer`. This is not
+// a standard redux function.
+export const localStoreSelector = instructorsReducer._localStoreSelector;
+export const instructorsSelector = createSelector(
+    localStoreSelector,
+    state => state._modelData
+);
 
 // Any time the active session changes, we want to refetch
 // all data. Calling `runOnActiveSessionChange` ensures that

--- a/frontend/src/api/actions/position_templates.js
+++ b/frontend/src/api/actions/position_templates.js
@@ -13,6 +13,8 @@ import {
     validatedApiDispatcher
 } from "./utils";
 import { apiGET, apiPOST } from "../../libs/apiUtils";
+import { positionTemplatesReducer } from "../reducers/position_templates";
+import { createSelector } from "reselect";
 
 // actions
 const fetchPositionTemplatesSuccess = actionFactory(
@@ -100,7 +102,16 @@ export const fetchAllPositionTemplates = validatedApiDispatcher({
 });
 
 // selectors
-export const positionTemplatesSelector = state => state._modelData;
+
+// Each reducer is given an isolated state; instead of needed to remember to
+// pass the isolated state to each selector, `reducer._localStoreSelector` will intelligently
+// search for and return the isolated state associated with `reducer`. This is not
+// a standard redux function.
+export const localStoreSelector = positionTemplatesReducer._localStoreSelector;
+export const positionTemplatesSelector = createSelector(
+    localStoreSelector,
+    state => state._modelData
+);
 
 // Any time the active session changes, we want to refetch
 // all data. Calling `runOnActiveSessionChange` ensures that

--- a/frontend/src/api/actions/positions.js
+++ b/frontend/src/api/actions/positions.js
@@ -13,6 +13,8 @@ import {
     validatedApiDispatcher
 } from "./utils";
 import { apiGET, apiPOST } from "../../libs/apiUtils";
+import { positionsReducer } from "../reducers/positions";
+import { createSelector } from "reselect";
 
 window.PT = PropTypes;
 
@@ -104,7 +106,16 @@ export const addInstructorToPosition = validatedApiDispatcher({
 });
 
 // selectors
-export const positionsSelector = state => state._modelData;
+
+// Each reducer is given an isolated state; instead of needed to remember to
+// pass the isolated state to each selector, `reducer._localStoreSelector` will intelligently
+// search for and return the isolated state associated with `reducer`. This is not
+// a standard redux function.
+export const localStoreSelector = positionsReducer._localStoreSelector;
+export const positionsSelector = createSelector(
+    localStoreSelector,
+    state => state._modelData
+);
 
 // Any time the active session changes, we want to refetch
 // all data. Calling `runOnActiveSessionChange` ensures that

--- a/frontend/src/api/actions/sessions.js
+++ b/frontend/src/api/actions/sessions.js
@@ -1,4 +1,5 @@
 import PropTypes from "prop-types";
+import { createSelector } from "reselect";
 import {
     FETCH_SESSIONS_SUCCESS,
     FETCH_ONE_SESSION_SUCCESS,
@@ -13,6 +14,7 @@ import {
     validatedApiDispatcher
 } from "./utils";
 import { apiGET, apiPOST } from "../../libs/apiUtils";
+import { sessionsReducer } from "../reducers/sessions";
 
 // actions
 const fetchSessionsSuccess = actionFactory(FETCH_SESSIONS_SUCCESS);
@@ -100,4 +102,8 @@ export const setActiveSession = validatedApiDispatcher({
 });
 
 // selectors
-export const sessionsSelector = state => state._modelData;
+export const localStoreSelector = sessionsReducer._localStoreSelector;
+export const sessionsSelector = createSelector(
+    localStoreSelector,
+    state => state._modelData
+);

--- a/frontend/src/api/actions/sessions.js
+++ b/frontend/src/api/actions/sessions.js
@@ -107,3 +107,7 @@ export const sessionsSelector = createSelector(
     localStoreSelector,
     state => state._modelData
 );
+export const activeSessionSelector = createSelector(
+    localStoreSelector,
+    state => state.activeSession
+);

--- a/frontend/src/api/reducers/applicants.js
+++ b/frontend/src/api/reducers/applicants.js
@@ -1,4 +1,3 @@
-import { createReducer } from "redux-create-reducer";
 import {
     FETCH_APPLICANTS_SUCCESS,
     FETCH_ONE_APPLICANT_SUCCESS,
@@ -6,7 +5,7 @@ import {
     DELETE_ONE_APPLICANT_SUCCESS,
     ADD_APPLICANT_TO_SESSION_SUCCESS
 } from "../constants";
-import { createBasicReducerObject } from "./utils";
+import { createBasicReducerObject, createReducer } from "./utils";
 
 const initialState = {
     _modelData: []

--- a/frontend/src/api/reducers/applications.js
+++ b/frontend/src/api/reducers/applications.js
@@ -1,11 +1,10 @@
-import { createReducer } from "redux-create-reducer";
 import {
     FETCH_APPLICATIONS_SUCCESS,
     FETCH_ONE_APPLICATION_SUCCESS,
     UPSERT_ONE_APPLICATION_SUCCESS,
     DELETE_ONE_APPLICATION_SUCCESS
 } from "../constants";
-import { createBasicReducerObject } from "./utils";
+import { createBasicReducerObject, createReducer } from "./utils";
 
 const initialState = {
     _modelData: []

--- a/frontend/src/api/reducers/assignments.js
+++ b/frontend/src/api/reducers/assignments.js
@@ -1,11 +1,10 @@
-import { createReducer } from "redux-create-reducer";
 import {
     FETCH_ASSIGNMENTS_SUCCESS,
     FETCH_ONE_ASSIGNMENT_SUCCESS,
     UPSERT_ONE_ASSIGNMENT_SUCCESS,
     DELETE_ONE_ASSIGNMENT_SUCCESS
 } from "../constants";
-import { createBasicReducerObject } from "./utils";
+import { createBasicReducerObject, createReducer } from "./utils";
 
 const initialState = {
     _modelData: []

--- a/frontend/src/api/reducers/instructors.js
+++ b/frontend/src/api/reducers/instructors.js
@@ -1,11 +1,10 @@
-import { createReducer } from "redux-create-reducer";
 import {
     FETCH_INSTRUCTORS_SUCCESS,
     FETCH_ONE_INSTRUCTOR_SUCCESS,
     UPSERT_ONE_INSTRUCTOR_SUCCESS,
     DELETE_ONE_INSTRUCTOR_SUCCESS
 } from "../constants";
-import { createBasicReducerObject } from "./utils";
+import { createBasicReducerObject, createReducer } from "./utils";
 
 const initialState = {
     _modelData: []

--- a/frontend/src/api/reducers/position_templates.js
+++ b/frontend/src/api/reducers/position_templates.js
@@ -1,4 +1,3 @@
-import { createReducer } from "redux-create-reducer";
 import {
     FETCH_POSITION_TEMPLATES_SUCCESS,
     FETCH_ONE_POSITION_TEMPLATE_SUCCESS,
@@ -6,7 +5,7 @@ import {
     DELETE_ONE_POSITION_TEMPLATE_SUCCESS,
     FETCH_ALL_POSITION_TEMPLATES_SUCCESS
 } from "../constants";
-import { createBasicReducerObject } from "./utils";
+import { createBasicReducerObject, createReducer } from "./utils";
 
 const initialState = {
     _modelData: [],

--- a/frontend/src/api/reducers/positions.js
+++ b/frontend/src/api/reducers/positions.js
@@ -1,4 +1,3 @@
-import { createReducer } from "redux-create-reducer";
 import {
     FETCH_POSITIONS_SUCCESS,
     FETCH_ONE_POSITION_SUCCESS,
@@ -6,7 +5,7 @@ import {
     DELETE_ONE_POSITION_SUCCESS,
     ADD_INSTRUCTOR_TO_POSITION_SUCCESS
 } from "../constants";
-import { createBasicReducerObject } from "./utils";
+import { createBasicReducerObject, createReducer } from "./utils";
 
 const initialState = {
     _modelData: []

--- a/frontend/src/api/reducers/sessions.js
+++ b/frontend/src/api/reducers/sessions.js
@@ -1,4 +1,3 @@
-import { createReducer } from "redux-create-reducer";
 import {
     FETCH_SESSIONS_SUCCESS,
     FETCH_ONE_SESSION_SUCCESS,
@@ -6,7 +5,7 @@ import {
     DELETE_ONE_SESSION_SUCCESS,
     SET_ACTIVE_SESSION
 } from "../constants";
-import { createBasicReducerObject } from "./utils";
+import { createBasicReducerObject, createReducer } from "./utils";
 
 const initialState = {
     _modelData: [],

--- a/frontend/src/api/reducers/status.js
+++ b/frontend/src/api/reducers/status.js
@@ -1,4 +1,4 @@
-import { createReducer } from "redux-create-reducer";
+import { createReducer } from "./utils";
 import { API_INTERACTION_START, API_INTERACTION_END } from "../constants";
 
 const initialState = {

--- a/frontend/src/api/reducers/utils.js
+++ b/frontend/src/api/reducers/utils.js
@@ -2,6 +2,9 @@
  * A set of utility functions to help with creating reducers
  */
 
+import { combineReducers as _origCombineReducers } from "redux";
+import { createReducer as _origCreateReducer } from "redux-create-reducer";
+
 /**
  * Either updates the item `modelData`
  * with id == newItem.id, or appends it.
@@ -10,7 +13,7 @@
  * @param {object} newItem
  * @returns {object} An updated version of modelData
  */
-function upsertItem(modelData, newItem) {
+export function upsertItem(modelData, newItem) {
     let didUpdate = false;
     const newModelData = modelData.map(item => {
         if (item.id === newItem.id) {
@@ -41,7 +44,7 @@ function upsertItem(modelData, newItem) {
  * @param {string} DELETE_ONE
  * @returns {object} An object of reducers suitable for passing to `createReducer`
  */
-function createBasicReducerObject(
+export function createBasicReducerObject(
     FETCH_MANY,
     FETCH_ONE,
     UPSERT_ONE,
@@ -72,4 +75,124 @@ function createBasicReducerObject(
     };
 }
 
-export { createBasicReducerObject, upsertItem };
+/**
+ * Wraps "redux-create-reducer"'s version of `createReducer` to add
+ * a `_storePath` attribute to the initial state and the reducer.
+ * `_storePath` is used by `localStoreSelector` to return the local
+ * state when passed in the global state. (For example, if
+ *    `state = { a: b: localState }`, then `localStoreSelector(state) === localState`.)
+ *
+ * @param {object} initialState
+ * @param {object} handlers
+ * @returns
+ */
+export function createReducer(initialState, handlers) {
+    const path = [];
+    function pushToPath(dir) {
+        path.unshift(dir);
+    }
+    // Every isolated state should have a unique id, so generate
+    // a random one.
+    const _storePath = { id: Math.random(), path, pushToPath };
+
+    // add _storePath to the initial state and to the
+    // new reducer
+    initialState._storePath = _storePath;
+    const reducer = _origCreateReducer(initialState, handlers);
+    reducer._storePath = _storePath;
+
+    // For convenience, attach a local store selector to the reducer
+    reducer._localStoreSelector = createLocalStoreSelector(_storePath);
+
+    return reducer;
+}
+
+/**
+ * Search `state` for a local state in the location of `_storePath.path`.
+ * For example, if `_storePath.path = ["a", "b"]`, this function will
+ * return `state.a.b`.
+ *
+ * @param {object} state Redux state
+ * @param {object} _storePath The `_storePath` object to use for searching `state`
+ * @returns
+ */
+function _localStoreSelector(state, _storePath) {
+    if (state._storePath && state._storePath.id === _storePath.id) {
+        return state;
+    }
+    try {
+        let localState = state;
+        for (const dir of _storePath.path) {
+            localState = localState[dir];
+        }
+        return localState;
+    } catch (e) {
+        // eslint-disable-next-line
+        console.error(
+            "Searching",
+            state,
+            "for local state with path",
+            _storePath.join("."),
+            "but encountered an error"
+        );
+    }
+    return state;
+}
+
+/**
+ * Create a selector that, when passed in the global redux state, will search
+ * and return a local state based on the information in `_storePath`. This selector
+ * can be passed either the local state or the global state. If it is passed the local
+ * state, it checks that the `state._storePath.id` field matches `_storePath.id`;
+ * if so, this selector immediately returns `state`. Otherwise, use `_storePath.path`
+ * to search for the local state. For example, if `_storePath.path = ["a", "b"]`,
+ * the returned selector will return `state.a.b`.
+ *
+ * @export
+ * @param {object} _storePath
+ * @param {array} _storePath.path The path to search in the redux state
+ * @param {array} _storePath.id The unique id of the local state
+ * @returns {Function} A selector that returns the local state (based on `_storePath`) when passed the global state
+ */
+export function createLocalStoreSelector(_storePath) {
+    return state => _localStoreSelector(state, _storePath);
+}
+
+/**
+ * Wraps "redux"'s `combineReducers` function so that `reducer._storePath.pushToPath`
+ * is called on all child reducers.
+ *
+ * Redux's `combineReducers` function creates a new reducer from `model` that dispatches
+ * actions to all reducers listed in `model`, but passes them an isolated part of the
+ * store instead of passing in the full redux store as `state`. This is great for writing
+ * reducers, but it makes things complicated for writing selectors, since, in general,
+ * a selector will get passed the whole state, not the isolated part of the state that
+ * `combineReducers` supplies. This wrapped version of `combineReducers` adds to a `path`
+ * variable that is present in each reducer and which can be passed to a smart selector.
+ *
+ * @export
+ * @param {object} model An object whose values are reducers
+ * @returns {Function} A reducer
+ */
+export function combineReducers(model) {
+    const pushToPathCallbacks = [];
+    // recursively call all `pushToPath` functions.
+    // They have been stored in `pushToPathCallbacks`
+    function pushToPath(dir) {
+        for (const func of pushToPathCallbacks) {
+            func(dir);
+        }
+    }
+
+    for (const [dir, reducer] of Object.entries(model)) {
+        if (reducer._storePath) {
+            reducer._storePath.pushToPath(dir);
+            pushToPathCallbacks.push(reducer._storePath.pushToPath);
+        }
+    }
+
+    const newReducer = _origCombineReducers(model);
+    newReducer._storePath = { pushToPath };
+
+    return newReducer;
+}

--- a/frontend/src/components/applicants-list.js
+++ b/frontend/src/components/applicants-list.js
@@ -1,0 +1,34 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+export class ApplicantsList extends React.Component {
+    static propTypes = {
+        applicants: PropTypes.arrayOf(
+            PropTypes.shape({
+                first_name: PropTypes.string,
+                last_name: PropTypes.string
+            })
+        ).isRequired
+    };
+    render() {
+        const { applicants } = this.props;
+        let applicantsList = <div>No Applicants...</div>;
+        if (applicants.length > 0) {
+            applicantsList = (
+                <ul>
+                    {applicants.map(applicant => (
+                        <li key={applicant.id}>
+                            {applicant.first_name} {applicant.last_name}
+                        </li>
+                    ))}
+                </ul>
+            );
+        }
+        return (
+            <div>
+                <h3>Available Applicants</h3>
+                {applicantsList}
+            </div>
+        );
+    }
+}

--- a/frontend/src/components/session-select.js
+++ b/frontend/src/components/session-select.js
@@ -1,0 +1,39 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Button, ButtonGroup } from "react-bootstrap";
+
+export class SessionSelect extends React.Component {
+    static propTypes = {
+        fetchSessions: PropTypes.func.isRequired,
+        setActiveSession: PropTypes.func.isRequired,
+        sessions: PropTypes.array.isRequired,
+        activeSession: PropTypes.object
+    };
+    componentDidMount() {
+        this.props.fetchSessions();
+    }
+    render() {
+        const { sessions, activeSession, setActiveSession } = this.props;
+        const activeSessionId = (activeSession || {}).id;
+        return (
+            <div>
+                <h3>Select Session</h3>
+                <ButtonGroup>
+                    {sessions.map(s => (
+                        <Button
+                            key={s.id}
+                            onClick={() => setActiveSession(s)}
+                            variant={
+                                activeSessionId === s.id
+                                    ? "primary"
+                                    : "secondary"
+                            }
+                        >
+                            {s.name}
+                        </Button>
+                    ))}
+                </ButtonGroup>
+            </div>
+        );
+    }
+}

--- a/frontend/src/modules/navigation/components/Header.jsx
+++ b/frontend/src/modules/navigation/components/Header.jsx
@@ -46,9 +46,14 @@ class Header extends React.Component {
                         path="/cp"
                         render={() => <Link to="/tapp/positions">CP</Link>}
                     />
+                    <Route
+                        path="/dashboard"
+                        render={() => <Link to="/tapp">Dashboard</Link>}
+                    />
                 </Navbar.Brand>
                 <Route path="/tapp" component={TappNavItems} />
                 <Route path="/cp" component={CpNavItems} />
+                <Route path="/dashboard" component={() => "(Dashboard View)"} />
                 <Nav>
                     <NavDropdown title="Tools" id="tools-dropdown">
                         <DropdownItem href="/tapp/positions/new">

--- a/frontend/src/rootReducer.js
+++ b/frontend/src/rootReducer.js
@@ -1,6 +1,6 @@
-import { combineReducers } from "redux";
 import { reducer as formReducer } from "redux-form";
 import { reducer as notificationReducer } from "react-notification-system-redux";
+import { combineReducers } from "./api/reducers/utils";
 import authReducer from "./modules/auth/reducer";
 import positionReducer from "./modules/positions/reducer";
 import applicantReducer from "./modules/applicants_by_course/reducer";

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -8,6 +8,7 @@ import AllUnassigned from "./modules/all_applicants/components/AllUnassigned";
 import Summary from "./modules/tapp_summary/components/Summary";
 import ApplicationForm from "./modules/application/components/ApplicationForm";
 import PositionsApplied from "./modules/applicants_positions/components/PositionsApplied";
+import Dashboard from "./views/dashboard";
 
 export const openRoutes = [
     {
@@ -41,6 +42,10 @@ export const openRoutes = [
     {
         path: "/cp",
         component: Screen
+    },
+    {
+        path: "/dashboard",
+        component: Dashboard
     },
     {
         path: "/application",

--- a/frontend/src/views/dashboard/index.js
+++ b/frontend/src/views/dashboard/index.js
@@ -6,22 +6,25 @@ import {
     sessionsSelector,
     applicantsSelector
 } from "../../api/actions";
+import { localStoreSelector as localSessionStoreSelector } from "../../api/actions/sessions";
 import { SessionSelect } from "../../components/session-select";
 import { ApplicantsList } from "../../components/applicants-list";
 
 // Connect the SessionSelect component
-let mapStateToProps = ({ model: { sessions } }) => ({
-    sessions: sessionsSelector(sessions),
-    activeSession: sessions.activeSession
-});
+let mapStateToProps = state => {
+    return {
+        sessions: sessionsSelector(state),
+        activeSession: localSessionStoreSelector(state).activeSession
+    };
+};
 let mapDispatchToProps = { fetchSessions, setActiveSession };
 const ConnectedSessionSelect = connect(
     mapStateToProps,
     mapDispatchToProps
 )(SessionSelect);
 
-const ConnectedApplicantList = connect(({ model: { applicants } }) => ({
-    applicants: applicantsSelector(applicants)
+const ConnectedApplicantList = connect(state => ({
+    applicants: applicantsSelector(state)
 }))(ApplicantsList);
 
 /**

--- a/frontend/src/views/dashboard/index.js
+++ b/frontend/src/views/dashboard/index.js
@@ -1,0 +1,69 @@
+import React from "react";
+import { connect } from "react-redux";
+import {
+    fetchSessions,
+    setActiveSession,
+    sessionsSelector,
+    applicantsSelector
+} from "../../api/actions";
+import { SessionSelect } from "../../components/session-select";
+import { ApplicantsList } from "../../components/applicants-list";
+
+// Connect the SessionSelect component
+let mapStateToProps = ({ model: { sessions } }) => ({
+    sessions: sessionsSelector(sessions),
+    activeSession: sessions.activeSession
+});
+let mapDispatchToProps = { fetchSessions, setActiveSession };
+const ConnectedSessionSelect = connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(SessionSelect);
+
+const ConnectedApplicantList = connect(({ model: { applicants } }) => ({
+    applicants: applicantsSelector(applicants)
+}))(ApplicantsList);
+
+/**
+ * Encapsulate a react component in a frame.
+ *
+ * @param {object} props
+ * @param {string} props.title The name of the component encapsulated
+ */
+function DashboardWidget(props) {
+    const { children, title } = props;
+    return (
+        <div style={{ margin: 5 }}>
+            <h5>
+                The{" "}
+                <span style={{ color: "green", fontFamily: "mono" }}>
+                    {title}
+                </span>{" "}
+                Component
+            </h5>
+            <div style={{ border: "1px solid black", padding: 5 }}>
+                {children}
+            </div>
+        </div>
+    );
+}
+
+/**
+ * A dashboard containing a sample of all the widgets connected
+ * appropriately to the redux store.
+ *
+ */
+function Dashboard() {
+    return (
+        <div>
+            <DashboardWidget title="SessionSelect">
+                <ConnectedSessionSelect />
+            </DashboardWidget>
+            <DashboardWidget title="ApplicantsList">
+                <ConnectedApplicantList />
+            </DashboardWidget>
+        </div>
+    );
+}
+
+export default Dashboard;

--- a/frontend/src/views/dashboard/index.js
+++ b/frontend/src/views/dashboard/index.js
@@ -4,9 +4,9 @@ import {
     fetchSessions,
     setActiveSession,
     sessionsSelector,
+    activeSessionSelector,
     applicantsSelector
 } from "../../api/actions";
-import { localStoreSelector as localSessionStoreSelector } from "../../api/actions/sessions";
 import { SessionSelect } from "../../components/session-select";
 import { ApplicantsList } from "../../components/applicants-list";
 
@@ -14,7 +14,7 @@ import { ApplicantsList } from "../../components/applicants-list";
 let mapStateToProps = state => {
     return {
         sessions: sessionsSelector(state),
-        activeSession: localSessionStoreSelector(state).activeSession
+        activeSession: activeSessionSelector(state)
     };
 };
 let mapDispatchToProps = { fetchSessions, setActiveSession };


### PR DESCRIPTION
The *dashboard* is a place to render the collection of working widgets/mini-views all in one place; it is meant for rapid prototyping.

This PR also adds smart local state selectors which will select the isolated state associated with each reducer.