### PR TITLE
[frontend/backend] Add Jest API unit tests

### DIFF
--- a/api/app/controllers/api/v1/sessions_controller.rb
+++ b/api/app/controllers/api/v1/sessions_controller.rb
@@ -11,13 +11,19 @@ module Api::V1
 
         # POST /sessions
         def create
+            # if we passed in an id that exists, we want to update the session
+            if params[:id] && Session.exists?(params[:id])
+		update and return
+	    end
+
+	    # when creating a new session, a name is required
             params.require(:name)
             session = Session.new(session_params)
             if session.save # passes Session model validation
                 render_success(session)
             else
                 session.destroy!
-                render_error(session.errors)
+                render_error(session.errors.full_messages.join("; "))
             end
         end
 
@@ -27,13 +33,24 @@ module Api::V1
             if session.update_attributes!(session_params)
                 render_success(session)
             else
-                render_error(session.errors)
+                render_error(session.errors.full_messages.join("; "))
             end
         end
+
+	# /sessions/delete or /sessions/:id/delete
+	def delete
+            session = Session.find(params[:id])
+            if session.destroy!
+                render_success(session)
+            else
+                render_error(session.errors.full_messages.join("; "))
+            end
+	end
 
         private
         def session_params
             params.permit(
+		:id,
                 :name,
                 :rate1,
                 :rate2,

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -26,6 +26,10 @@ Rails.application.routes.draw do
       resources :applications, only: [:index, :update] do
         post '/add_preference', to: 'position_preferences#create'
       end
+
+      # session routes
+      post '/sessions/delete' => 'sessions#delete'
+      post '/sessions/:id/delete' => 'sessions#delete'
       resources :sessions, only: [:index, :create, :update] do
         resources :positions, only: [:index, :create]
         resources :position_templates, only: [:index]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
     },
     "browserslist": [],
     "devDependencies": {
+        "axios": "^0.19.0",
         "redux-devtools-extension": "^2.13.5"
     }
 }

--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -1,0 +1,75 @@
+import PropTypes from "prop-types";
+import { apiGET, apiPOST, checkPropTypes, sessionPropTypes } from "./utils";
+import { mockAPI } from "../api/mockAPI";
+// eslint-disable-next-line
+const { describe, it, expect } = global;
+//global.XMLHttpRequest = undefined
+
+/**
+ * Tests for the API. These are encapsulated in a function so that
+ * different `apiGET` and `apiPOST` functions can be passed in. For example,
+ * they may be functions that make actual requests via http or they may
+ * be from the mock API.
+ *
+ * @param {Function} apiGET
+ * @param {Function} apiPOST
+ */
+function apiTests(apiGET, apiPOST) {
+    it("fetch sessions", async () => {
+        const resp = await apiGET("/sessions");
+
+        expect(resp).toMatchObject({ status: "success" });
+        checkPropTypes(PropTypes.arrayOf(sessionPropTypes), resp.payload);
+    });
+    it("create and delete session", async () => {
+        const newSessionData = {
+            start_date: "2019/09/09",
+            end_date: "2019/12/31",
+            // add a random string to the session name so we don't accidentally collide with another
+            // session's name
+            name: "Newly Created Sessions (" + Math.random() + ")",
+            rate1: 56.54
+        };
+        // get all the sessions so that we can check that our newly inserted session has
+        // a unique id.
+        const { payload: initialSessions } = await apiGET("/sessions");
+        // do we get a success response when creating the session?
+        const resp1 = await apiPOST("/sessions", newSessionData);
+        expect(resp1).toMatchObject({ status: "success" });
+        const { payload: createdSession } = resp1;
+        // make sure the propTypes are right
+        checkPropTypes(sessionPropTypes, createdSession);
+        // make sure the data we get back is the same we put in
+        expect(createdSession).toMatchObject(newSessionData);
+        // make sure we have an id
+        expect(createdSession.id).not.toBeNull();
+        // make sure the id is unique and wasn't already a session id
+        expect(initialSessions.map(x => x.id)).not.toContain(createdSession.id);
+
+        // fetch all sessions and make sure we're in there
+        const { payload: withNewSessions } = await apiGET("/sessions");
+        expect(withNewSessions.length).toBeGreaterThan(initialSessions.length);
+        // make sure the id of our new session came back
+        expect(withNewSessions.map(x => x.id)).toContain(createdSession.id);
+
+        // now delete the session and make sure it's gone
+        const resp2 = await apiPOST("/sessions/delete", {
+            id: createdSession.id
+        });
+        expect(resp2).toMatchObject({ status: "success" });
+        const { payload: withoutNewSessions } = await apiGET("/sessions");
+        expect(withoutNewSessions.map(x => x.id)).not.toContain(
+            createdSession.id
+        );
+    });
+}
+describe("API tests", () => {
+    apiTests(apiGET, apiPOST);
+});
+
+describe("Mock API tests", () => {
+    apiTests(
+        (...args) => mockAPI.apiGET(...args),
+        (...args) => mockAPI.apiPOST(...args)
+    );
+});

--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -1,9 +1,47 @@
 import PropTypes from "prop-types";
-import { apiGET, apiPOST, checkPropTypes, sessionPropTypes } from "./utils";
+import {
+    apiGET,
+    apiPOST,
+    checkPropTypes,
+    sessionPropTypes,
+    offerTemplateMinimalPropTypes,
+    offerTemplatePropTypes
+} from "./utils";
 import { mockAPI } from "../api/mockAPI";
 // eslint-disable-next-line
 const { describe, it, expect } = global;
-//global.XMLHttpRequest = undefined
+
+// add a custom `.toContainObject` method to `expect()` to see if an array contains
+// an object with matching props. Taken from
+// https://medium.com/@andrei.pfeiffer/jest-matching-objects-in-array-50fe2f4d6b98
+expect.extend({
+    toContainObject(received, argument) {
+        const pass = this.equals(
+            received,
+            expect.arrayContaining([expect.objectContaining(argument)])
+        );
+
+        if (pass) {
+            return {
+                message: () =>
+                    `expected ${this.utils.printReceived(
+                        received
+                    )} not to contain object ${this.utils.printExpected(
+                        argument
+                    )}`,
+                pass: true
+            };
+        } else {
+            return {
+                message: () =>
+                    `expected ${this.utils.printReceived(
+                        received
+                    )} to contain object ${this.utils.printExpected(argument)}`,
+                pass: false
+            };
+        }
+    }
+});
 
 /**
  * Tests for the API. These are encapsulated in a function so that
@@ -14,7 +52,7 @@ const { describe, it, expect } = global;
  * @param {Function} apiGET
  * @param {Function} apiPOST
  */
-function apiSessionsTests(apiGET, apiPOST) {
+function sessionsTests(apiGET, apiPOST) {
     it("fetch sessions", async () => {
         const resp = await apiGET("/sessions");
 
@@ -66,14 +104,92 @@ function apiSessionsTests(apiGET, apiPOST) {
     it.todo("throw error when `name` is not unique");
     it.todo("throw error when deleting item with invalid id");
 }
+function templateTests(apiGET, apiPOST) {
+    it("fetch available templates", async () => {
+        const resp = await apiGET("/available_position_templates");
+
+        expect(resp).toMatchObject({ status: "success" });
+        checkPropTypes(
+            PropTypes.arrayOf(offerTemplateMinimalPropTypes),
+            resp.payload
+        );
+    });
+    it("add template to session", async () => {
+        const newSessionData = {
+            start_date: "2019/09/09",
+            end_date: "2019/12/31",
+            // add a random string to the session name so we don't accidentally collide with another
+            // session's name
+            name: "Newly Created Sessions (" + Math.random() + ")",
+            rate1: 56.54
+        };
+        const newTemplateData = {
+            offer_template: "this_is_a_test_template.html",
+            position_type: "OTO"
+        };
+        const newTemplateData2 = {
+            offer_template: "this_is_a_test_template.html",
+            position_type: "Invigilate"
+        };
+        // create a new session to add a template to
+        const resp1 = await apiPOST("/sessions", newSessionData);
+        expect(resp1).toMatchObject({ status: "success" });
+        const sessionId = resp1.payload.id;
+
+        // grab the position_templates of the new session. They may have
+        // pre-populated.
+        const resp2 = await apiGET(`/sessions/${sessionId}/position_templates`);
+        expect(resp2).toMatchObject({ status: "success" });
+        checkPropTypes(
+            PropTypes.arrayOf(offerTemplatePropTypes),
+            resp2.payload
+        );
+
+        // add the new offer template
+        const resp3 = await apiPOST(
+            `/sessions/${sessionId}/add_position_template`,
+            newTemplateData
+        );
+        expect(resp3).toMatchObject({ status: "success" });
+        checkPropTypes(
+            PropTypes.arrayOf(offerTemplatePropTypes),
+            resp3.payload
+        );
+        expect(resp3.payload).toContainObject(newTemplateData);
+
+        // another one -- it should contain both of our added templates
+        const resp4 = await apiPOST(
+            `/sessions/${sessionId}/add_position_template`,
+            newTemplateData2
+        );
+        expect(resp4.payload).toContainObject(newTemplateData);
+        expect(resp4.payload).toContainObject(newTemplateData2);
+
+        // fetching the templates again should give us the same list
+        const resp5 = await apiGET(`/sessions/${sessionId}/position_templates`);
+        expect(resp5.payload).toEqual(resp4.payload);
+
+        // clean up by deleting the session
+        await apiPOST("/sessions/delete", {
+            id: sessionId
+        });
+    });
+    it.todo("throw error when `offer_template` or `position_type` is empty");
+    it.todo("throw error when `position_type` is not unique");
+}
+
+// Run the actual tests for both the API and the Mock API
 describe("API tests", () => {
     describe("`/sessions` tests", () => {
-        apiSessionsTests(apiGET, apiPOST);
+        sessionsTests(apiGET, apiPOST);
+    });
+    describe("template tests", () => {
+        templateTests(apiGET, apiPOST);
     });
 });
 
 describe("Mock API tests", () => {
     describe("`/sessions` tests", () => {
-        apiSessionsTests(mockAPI.apiGET, mockAPI.apiPOST);
+        sessionsTests(mockAPI.apiGET, mockAPI.apiPOST);
     });
 });

--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -14,7 +14,7 @@ const { describe, it, expect } = global;
  * @param {Function} apiGET
  * @param {Function} apiPOST
  */
-function apiTests(apiGET, apiPOST) {
+function apiSessionsTests(apiGET, apiPOST) {
     it("fetch sessions", async () => {
         const resp = await apiGET("/sessions");
 
@@ -62,14 +62,18 @@ function apiTests(apiGET, apiPOST) {
             createdSession.id
         );
     });
+    it.todo("throw error when `name` is empty");
+    it.todo("throw error when `name` is not unique");
+    it.todo("throw error when deleting item with invalid id");
 }
 describe("API tests", () => {
-    apiTests(apiGET, apiPOST);
+    describe("`/sessions` tests", () => {
+        apiSessionsTests(apiGET, apiPOST);
+    });
 });
 
 describe("Mock API tests", () => {
-    apiTests(
-        (...args) => mockAPI.apiGET(...args),
-        (...args) => mockAPI.apiPOST(...args)
-    );
+    describe("`/sessions` tests", () => {
+        apiSessionsTests(mockAPI.apiGET, mockAPI.apiPOST);
+    });
 });

--- a/frontend/src/__tests__/utils.js
+++ b/frontend/src/__tests__/utils.js
@@ -15,7 +15,7 @@ function _ensurePath(path) {
 }
 
 /**
- * Make a GET request to the api route specified by `url`. 
+ * Make a GET request to the api route specified by `url`.
  * `url` should *not* be prefixed (e.g., just "/sessions", not "/api/v1/sessiosn")
  *
  * @export
@@ -27,13 +27,13 @@ export async function apiGET(url) {
     const resp = await axios.get(url);
     isApiSuccessResponse(resp);
 
-    // by this point, we have a valid response, so 
+    // by this point, we have a valid response, so
     // just return the payload
     return resp.data;
 }
 
 /**
- * Make a POST request to the api route specified by `url`. 
+ * Make a POST request to the api route specified by `url`.
  * `url` should *not* be prefixed (e.g., just "/sessions", not "/api/v1/sessiosn")
  *
  * @export
@@ -41,12 +41,12 @@ export async function apiGET(url) {
  * @param {object} body The body of the post request -- `JSON.stringify` will be called on this object.
  * @returns
  */
-export async function apiPOST(url, body={}) {
+export async function apiPOST(url, body = {}) {
     url = API_URL + _ensurePath(url);
     const resp = await axios.post(url, body);
     isApiSuccessResponse(resp);
 
-    // by this point, we have a valid response, so 
+    // by this point, we have a valid response, so
     // just return the payload
     return resp.data;
 }

--- a/frontend/src/__tests__/utils.js
+++ b/frontend/src/__tests__/utils.js
@@ -1,0 +1,109 @@
+import axios from "axios";
+import PropTypes from "prop-types";
+// eslint-disable-next-line
+const { expect, test } = global;
+
+// Jest demands there be a test in every file, so we put a no-op test here.
+test("no-op", () => {});
+
+/** URL prefix for making API calls from inside a docker image */
+export const API_URL = "http://api:3000/api/v1";
+
+// Ensure that `path` starts with a `/`
+function _ensurePath(path) {
+    return path.startsWith("/") ? path : "/" + path;
+}
+
+/**
+ * Make a GET request to the api route specified by `url`. 
+ * `url` should *not* be prefixed (e.g., just "/sessions", not "/api/v1/sessiosn")
+ *
+ * @export
+ * @param {string} url The api un-prefixed url route (e.g. "/sessions")
+ * @returns
+ */
+export async function apiGET(url) {
+    url = API_URL + _ensurePath(url);
+    const resp = await axios.get(url);
+    isApiSuccessResponse(resp);
+
+    // by this point, we have a valid response, so 
+    // just return the payload
+    return resp.data;
+}
+
+/**
+ * Make a POST request to the api route specified by `url`. 
+ * `url` should *not* be prefixed (e.g., just "/sessions", not "/api/v1/sessiosn")
+ *
+ * @export
+ * @param {string} url The api un-prefixed url route (e.g. "/sessions")
+ * @param {object} body The body of the post request -- `JSON.stringify` will be called on this object.
+ * @returns
+ */
+export async function apiPOST(url, body={}) {
+    url = API_URL + _ensurePath(url);
+    const resp = await axios.post(url, body);
+    isApiSuccessResponse(resp);
+
+    // by this point, we have a valid response, so 
+    // just return the payload
+    return resp.data;
+}
+
+/**
+ * Test whether the axios response `response`
+ * conforms to the standard api success response
+ *
+ * @export
+ * @param {object} response An axios response
+ */
+export function isApiSuccessResponse(response) {
+    const { status, data } = response;
+    expect(status).toEqual(200);
+    expect(data.status).toEqual("success");
+}
+
+/**
+ * Test whether the axios response `response`
+ * conforms to the standard api error response
+ *
+ * @export
+ * @param {object} response An axios response
+ */
+export function isApiErrorResponse(response) {
+    const { status, data } = response;
+    if (status === 200) {
+        expect(data.status).toEqual("error");
+        expect(data.message.length > 0).toBe(true);
+    }
+}
+
+/**
+ * Checks that `data` conforms to the prop types
+ * specified by `propTypes`.
+ *
+ * @export
+ * @param {PropTypes} propTypes
+ * @param {object} data
+ */
+export function checkPropTypes(propTypes, data) {
+    let wasPropTypeErrors = false;
+    PropTypes.checkPropTypes(
+        { "<root>": propTypes },
+        { "<root>": data },
+        "PropType verification",
+        "the client",
+        () => {
+            wasPropTypeErrors = true;
+        }
+    );
+    expect(wasPropTypeErrors).toBe(false);
+}
+
+export const sessionPropTypes = PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    start_date: PropTypes.string,
+    end_date: PropTypes.string,
+    name: PropTypes.string
+});

--- a/frontend/src/__tests__/utils.js
+++ b/frontend/src/__tests__/utils.js
@@ -107,3 +107,12 @@ export const sessionPropTypes = PropTypes.shape({
     end_date: PropTypes.string,
     name: PropTypes.string
 });
+
+export const offerTemplateMinimalPropTypes = PropTypes.shape({
+    offer_template: PropTypes.string
+});
+
+export const offerTemplatePropTypes = PropTypes.shape({
+    offer_template: PropTypes.string,
+    position_type: PropTypes.string
+});

--- a/frontend/src/api/mockAPI.js
+++ b/frontend/src/api/mockAPI.js
@@ -62,7 +62,7 @@ export class MockAPI {
             data.sessions.push(newSession);
             return newSession;
         },
-        "/sessions/delete": (data, params, body) => {
+        "/sessions/delet": (data, params, body) => {
             const matchingSessions = data.sessions.filter(
                 s => s.id === body.id
             );

--- a/frontend/src/api/mockAPI.js
+++ b/frontend/src/api/mockAPI.js
@@ -62,7 +62,7 @@ export class MockAPI {
             data.sessions.push(newSession);
             return newSession;
         },
-        "/sessions/delet": (data, params, body) => {
+        "/sessions/delete": (data, params, body) => {
             const matchingSessions = data.sessions.filter(
                 s => s.id === body.id
             );

--- a/frontend/src/api/mockAPI.js
+++ b/frontend/src/api/mockAPI.js
@@ -27,26 +27,63 @@ export class MockAPI {
     // a list of selectors for each route
     getRoutes = {
         "/all_data": data => data,
-        "/sessions": data => data.sessions,
+        "/sessions": data => [...data.sessions],
         "/instructors": data => data.instructors,
-        "/available_position_templates": data =>
-            data.available_position_templates,
-        "/sessions/:session_id/positions": (data, params) =>
-            data.positions[params.session_id],
-        "/sessions/:session_id/assignments": (data, params) =>
-            data.assignments[params.session_id],
-        "/sessions/:session_id/position_templates": (data, params) =>
-            data.position_templates_by_session[params.session_id],
+        "/available_position_templates": data => [
+            ...data.available_position_templates
+        ],
+        "/sessions/:session_id/positions": (data, params) => [
+            ...data.positions[params.session_id]
+        ],
+        "/sessions/:session_id/assignments": (data, params) => [
+            ...data.assignments[params.session_id]
+        ],
+        "/sessions/:session_id/position_templates": (data, params) => [
+            ...data.position_templates_by_session[params.session_id]
+        ],
         "/sessions/:session_id/applicants": (data, params) =>
             data.applicants_by_session[params.session_id].map(utorid =>
                 pickFromArray(data.applicants, utorid, "utorid")
             )
+    };
+    postRoutes = {
+        "/sessions": (data, params, body) => {
+            // body should be a session object. If it contains an id,
+            // update an existing session. Otherwise, create a new one.
+            const matchingSessions = data.sessions.filter(
+                s => s.id === body.id
+            );
+            if (matchingSessions.length > 0) {
+                return Object.assign(matchingSessions[0], body);
+            }
+            // if we're here, we need to create a new session
+            const newId = Math.floor(Math.random() * 1000);
+            const newSession = { ...body, id: newId };
+            data.sessions.push(newSession);
+            return newSession;
+        },
+        "/sessions/delete": (data, params, body) => {
+            const matchingSessions = data.sessions.filter(
+                s => s.id === body.id
+            );
+            if (matchingSessions.length === 0) {
+                throw new Error(
+                    `Could not find session with id=${body.id} to delete`
+                );
+            }
+            // if we found the session with matching id, delete it.
+            data.sessions.splice(data.sessions.indexOf(matchingSessions[0]), 1);
+            return {};
+        }
     };
 
     constructor(seedData) {
         this.active = false;
         this.data = seedData;
         this._getRoutesParsers = Object.keys(this.getRoutes).map(
+            routeStr => new Route(routeStr)
+        );
+        this._postRoutesParsers = Object.keys(this.postRoutes).map(
             routeStr => new Route(routeStr)
         );
     }
@@ -85,10 +122,29 @@ export class MockAPI {
     }
 
     apiPOST(url, body) {
+        for (const route of this._postRoutesParsers) {
+            const match = route.match(url);
+            // if we have a match, run the selector with the parsed data
+            if (match) {
+                try {
+                    const payload = this.postRoutes[route.spec](
+                        this.data,
+                        match,
+                        body
+                    );
+                    return {
+                        status: "success",
+                        message: "",
+                        payload
+                    };
+                } catch (e) {
+                    return { status: "error", message: e.toString() };
+                }
+            }
+        }
         return {
             status: "error",
-            message: "Posting to the mock API is not yet implemented",
-            payload: { url, body }
+            message: `could not find route matching ${url}`
         };
     }
 

--- a/frontend/src/api/mockAPI.js
+++ b/frontend/src/api/mockAPI.js
@@ -88,7 +88,16 @@ export class MockAPI {
         );
     }
 
-    apiGET(url) {
+    /**
+     * Make a mock `apiGET` call. Always returns an object of
+     * the form
+     * `{status: ..., message: ..., payload: ...}`
+     * This method is bound, so it is safe to pass this function around.
+     *
+     * @memberof MockAPI
+     * @param {string} url An API route without `/api/v1` (e.g., `/sessions`)
+     */
+    apiGET = url => {
         for (const route of this._getRoutesParsers) {
             const match = route.match(url);
             // if we have a match, run the selector with the parsed data
@@ -119,9 +128,19 @@ export class MockAPI {
             status: "error",
             message: `could not find route matching ${url}`
         };
-    }
+    };
 
-    apiPOST(url, body) {
+    /**
+     * Make a mock `apiPOST` call. Always returns an object of
+     * the form
+     * `{status: ..., message: ..., payload: ...}`
+     * This method is bound, so it is safe to pass this function around.
+     *
+     * @memberof MockAPI
+     * @param {string} url An API route without `/api/v1` (e.g., `/sessions`)
+     * @param {object} body The body of a post request. This should be an object, *not* a JSON string.
+     */
+    apiPOST = (url, body) => {
         for (const route of this._postRoutesParsers) {
             const match = route.match(url);
             // if we have a match, run the selector with the parsed data
@@ -146,7 +165,7 @@ export class MockAPI {
             status: "error",
             message: `could not find route matching ${url}`
         };
-    }
+    };
 
     /**
      * Replaces the global `window.fetch` object with calls to `apiGET` and

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1906,6 +1906,14 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
+axios@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
+  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+  dependencies:
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
+
 axobject-query@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.0.2.tgz#ea187abe5b9002b377f925d8bf7d1c561adf38f9"
@@ -3218,6 +3226,13 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@^3.2.5, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
@@ -4208,6 +4223,13 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
+
 follow-redirects@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
@@ -5120,7 +5142,7 @@ is-buffer@^1.0.2, is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-buffer@^2.0.0:
+is-buffer@^2.0.0, is-buffer@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
   integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==

--- a/tests/run-unit-tests.sh
+++ b/tests/run-unit-tests.sh
@@ -17,5 +17,7 @@ echo 'If they are not, please run `docker-compose up` and rerun this script.'
 
 # Run all tapp unit tests
 echo "Running Unit Tests..."
+# set the CI variable to true so that `npm test` doesn't run in --watch mode.
+docker-compose run -e CI=true frontend npm test
 
 exit $EXIT_CODE


### PR DESCRIPTION
Jest is the preferred framework for create-react-app created apps to run unit tests. You can also make http requests inside Jest tests. This PR creates a basic API test and runs it against the rails api and the mock api.