### PR TITLE
fix(api): added error handling for undefined api routes

### DIFF
--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -7,10 +7,9 @@ class ApplicationController < ActionController::Base
 
   	def index
     	render :file => 'public/index.html'
-		end  
+    end  
 		
 		def not_found
-			raise ActionController::RoutingError.new('Unknown Route')
+			render json: {status: 'not_found'}, status: :not_found
 		end
-
 end

--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -7,6 +7,10 @@ class ApplicationController < ActionController::Base
 
   	def index
     	render :file => 'public/index.html'
-  	end  
+		end  
+		
+		def not_found
+			raise ActionController::RoutingError.new('Unknown Route')
+		end
 
 end

--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -5,11 +5,11 @@ class ApplicationController < ActionController::Base
   	include Response
   	include ExceptionHandler
 
-  	def index
-    	render :file => 'public/index.html'
+    def index
+      render :file => 'public/index.html'
     end  
 		
-		def not_found
-			render_error('unknown route')
-		end
+    def not_found
+      render_error('unknown route')
+    end
 end

--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -10,6 +10,6 @@ class ApplicationController < ActionController::Base
     end  
 		
 		def not_found
-			render json: {status: 'not_found'}, status: :not_found
+			render_error('unknown route')
 		end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -46,8 +46,19 @@ Rails.application.routes.draw do
       post '/email_offer', to: 'offers#email_offer'
       post '/ta/offers/:offer_id/respond_to_offer', to: 'offers#respond'
     end
+
+    # This route makes sure that any requests with URLs of the form '/api/*' 
+    # with no corresponding route gets a 404 instead of the frontend index file.
+    # Redirecting to a specialized 404 route because this route is namespaced and
+    # cannot call actions from the application controller.
+    get '*path', to: redirect('/404')
   end
 
+  # This route returns a 404 error status by throwing a rails routing error.  
+  get '/404', to: 'application#not_found'
+
+  # This matches all routes that do not begin with '/api' and returns the frontend
+  # index file.  The request URL is then given to react router.  
   get '*path', to: "application#index", constraints: ->(request) do
         !request.xhr? && request.format.html?
   end

--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -326,11 +326,6 @@ function applicationsTests({ apiGET, apiPOST }) {}
 function unknownRouteTests(api = { apiGet, apiPost }) {
     const { apiGet, apiPost } = api;
 
-    it("should succeed GET request with known '/api' routes", async () => {
-        const resp = await apiGET("/sessions");
-        expect(resp).toMatchObject({ status: "success" });
-    });
-
     it("should fail GET request with unknown '/api' routes", async () => {
         const resp = await apiGET("/some_string");
         expect(resp).toMatchObject({ status: "error" });
@@ -366,7 +361,7 @@ describe("API tests", () => {
     describe("`/applications` tests", () => {
         applicationsTests({ apiGET, apiPOST });
     });
-    describe("`/404` tests", () => {
+    describe("unknown api route tests", () => {
         unknownRouteTests({ apiGET, apiPOST });
     });
 });

--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -324,7 +324,7 @@ function reportingTagsTests({ apiGET, apiPOST }) {
 function applicationsTests({ apiGET, apiPOST }) {}
 
 function unknownRouteTests(api = { apiGet, apiPost }) {
-    const {apiGet, apiPost} = api;
+    const { apiGet, apiPost } = api;
 
     it("should succeed GET request with known '/api' routes", async () => {
         const resp = await apiGET("/sessions");
@@ -332,9 +332,9 @@ function unknownRouteTests(api = { apiGet, apiPost }) {
     });
 
     it("should fail GET request with unknown '/api' routes", async () => {
-        try { 
+        try {
             await apiGET("/some_string");
-        } catch(e) { 
+        } catch (e) {
             expect(e.response.data).toMatchObject({ status: "not_found" });
         }
     });

--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -332,11 +332,8 @@ function unknownRouteTests(api = { apiGet, apiPost }) {
     });
 
     it("should fail GET request with unknown '/api' routes", async () => {
-        try {
-            await apiGET("/some_string");
-        } catch (e) {
-            expect(e.response.data).toMatchObject({ status: "not_found" });
-        }
+        const resp = await apiGET("/some_string");
+        expect(resp).toMatchObject({ status: "error" });
     });
 }
 

--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -333,7 +333,7 @@ function unknownRouteTests(api = { apiGet, apiPost }) {
 
     it("should fail GET request with unknown '/api' routes", async () => {
         try { 
-            const resp = await apiGET("/some_string");
+            await apiGET("/some_string");
         } catch(e) { 
             expect(e.response.data).toMatchObject({ status: "not_found" });
         }

--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -323,6 +323,23 @@ function reportingTagsTests({ apiGET, apiPOST }) {
 // eslint-disable-next-line
 function applicationsTests({ apiGET, apiPOST }) {}
 
+function unknownRouteTests(api = { apiGet, apiPost }) {
+    const {apiGet, apiPost} = api;
+
+    it("should succeed GET request with known '/api' routes", async () => {
+        const resp = await apiGET("/sessions");
+        expect(resp).toMatchObject({ status: "success" });
+    });
+
+    it("should fail GET request with unknown '/api' routes", async () => {
+        try { 
+            const resp = await apiGET("/some_string");
+        } catch(e) { 
+            expect(e.response.data).toMatchObject({ status: "not_found" });
+        }
+    });
+}
+
 // Run the actual tests for both the API and the Mock API
 describe("API tests", () => {
     describe("`/sessions` tests", () => {
@@ -351,6 +368,9 @@ describe("API tests", () => {
     });
     describe("`/applications` tests", () => {
         applicationsTests({ apiGET, apiPOST });
+    });
+    describe("`/404` tests", () => {
+        unknownRouteTests({ apiGET, apiPOST });
     });
 });
 


### PR DESCRIPTION
Added a 404 route that matches urls for undefined '/api' routes for the rails backend.  Previously, undefined api routes are handled as frontend react router routes and rails would return a 200 status.  