### PR TITLE
Issue #204 Added fix for server hang when making concurrent API calls

### DIFF
--- a/api/config/environments/development.rb
+++ b/api/config/environments/development.rb
@@ -9,7 +9,7 @@ Rails.application.configure do
   config.cache_classes = false
 
   # Do not eager load code on boot.
-  config.eager_load = false
+  config.eager_load = true
 
   # Show full error reports.
   config.consider_all_requests_local = true


### PR DESCRIPTION
Noticed that when I was trying to run my API calls (Specifically in the session routes) the server would hang and it would not populate the data properly. Forcing shut down and doing docker-compose up again would yield different results without having changed any code. I.e. sometimes the Positions view on the dashboard would populate, sometimes multiple views, and sometimes none. 


I fixed this problem by setting: 

`config.eager_load = true`

in /api/config/environments/development.rb
