### PR TITLE
fix(test): fix typo in rubocop.yml

### DIFF
--- a/api/.rubocop.yml
+++ b/api/.rubocop.yml
@@ -44,5 +44,5 @@ Style/ClassAndModuleChildren:
 Style/GuardClause:
   Enabled: false
 
-Style/OneLineConditiona:
+Style/OneLineConditional:
   Enabled: false


### PR DESCRIPTION
add missing l in 'Style/OneLineConditiona'