### PR TITLE
fix(travis): lock babel-eslint at @10.0.2 to fix no-unused-var issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       cache: yarn
       before_script:
         # ESLint version is restricted to version 6.1.0 as per issue 209
-        - yarn add eslint@6.1.0 babel-eslint eslint-plugin-react prettier prettier-check
+        - yarn add eslint@6.1.0 babel-eslint@10.0.2 eslint-plugin-react prettier prettier-check
       script:
         # allow these tests to fail for now...
         - ./tests/run-formatting-tests.sh


### PR DESCRIPTION
- This is a follow-up to issue #209 
- This fixes the `Code Formatting Tests` on Travis so that it passes