### PR TITLE
Persist mockAPI state in the URL

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,8 +6,41 @@ import { openRoutes, privateRoutes } from "./routes";
 import OpenRoute from "./modules/auth/components/OpenRoute";
 import PrivateRoute from "./modules/auth/components/PrivateRoute";
 import Header from "./modules/navigation/components/Header";
+import { connect } from "react-redux";
+import { setGlobals } from "./views/globals/actions";
+import { parseURLSearchString } from "./libs/urlUtils";
+import { runOnActiveSessionChange } from "./api/actions/utils";
+import { setActiveSession } from "./api/actions";
 
 class App extends React.Component {
+    componentDidMount() {
+        // Some special values can be persisted in the url search string.
+        // This is mainly for development with the mockAPI so that a page
+        // can be refreshed and appear in the same state that it was.
+        if (!window.location) {
+            return;
+        }
+        const newGlobals = parseURLSearchString(window.location.search);
+        this.props.setGlobals(newGlobals);
+
+        // Set up a special handler for when the active session changes. We want to store
+        // this in the URL string
+        runOnActiveSessionChange(() => async (dispatch, getState) => {
+            const state = getState();
+            const activeSession = state.model.sessions.activeSession;
+            const globals = state.ui.globals;
+            this.props.setGlobals({
+                ...globals,
+                activeSession: activeSession.id
+            });
+        });
+        // If there is an `activeSession` stored in globals, use it to set the active
+        // session now. (This is a one-time action)
+        if (newGlobals.activeSession != null) {
+            this.props.setActiveSession({ id: newGlobals.activeSession });
+        }
+    }
+
     render() {
         return (
             <React.Fragment>
@@ -33,4 +66,11 @@ class App extends React.Component {
     }
 }
 
-export default App;
+const ConnectedApp = connect(
+    state => ({
+        globals: state.ui.globals
+    }),
+    { setGlobals, setActiveSession }
+)(App);
+
+export default ConnectedApp;

--- a/frontend/src/api/mockAPI.js
+++ b/frontend/src/api/mockAPI.js
@@ -251,7 +251,7 @@ export const mockData = {
             id: 2,
             start_date: "2020-01-01T00:00:00.000Z",
             end_date: "2020-04-30T00:00:00.000Z",
-            name: "2020 Spring",
+            name: "2021 Spring",
             rate1: 45.55,
             rate2: null
         }

--- a/frontend/src/libs/urlUtils.js
+++ b/frontend/src/libs/urlUtils.js
@@ -1,0 +1,30 @@
+/*
+ * A collection of untilty functions for interfacing with urls
+ */
+
+/**
+ * Try to parse `s` as a native javascript type. E.g., "45.6" will
+ * be parsed as a number, "true" will be parsed as `true`, "[]"
+ * will be parsed as an empty array.
+ *
+ * @param {string} s
+ * @returns
+ */
+function stringToNativeType(s) {
+    try {
+        return JSON.parse(s);
+    } catch (e) {
+        return s;
+    }
+}
+
+function parseURLSearchString(s) {
+    const searchParams = new URLSearchParams(s);
+    const ret = {};
+    for (const [key, val] of searchParams.entries()) {
+        ret[key] = stringToNativeType(val);
+    }
+    return ret;
+}
+
+export { stringToNativeType, parseURLSearchString };

--- a/frontend/src/rootReducer.js
+++ b/frontend/src/rootReducer.js
@@ -8,6 +8,7 @@ import instructorReducer from "./modules/instructors/reducer";
 import applicationReducer from "./views/application_form/reducer";
 import applicantsPositionReducer from "./modules/applicants_positions/reducer";
 import offerTableReducer from "./views/offertable/reducers";
+import { globalReducer } from "./views/globals/reducers";
 import {
     statusReducer,
     sessionsReducer,
@@ -50,7 +51,8 @@ const reducer = combineReducers({
         instructors: instructorReducer,
         application: applicationReducer,
         applicantsPositions: applicantsPositionReducer,
-        offerTable: offerTableReducer
+        offerTable: offerTableReducer,
+        globals: globalReducer
     })
 });
 

--- a/frontend/src/views/globals/actions.js
+++ b/frontend/src/views/globals/actions.js
@@ -1,0 +1,19 @@
+export function setGlobals(globals = {}, location = window.location) {
+    const searchParams = new URLSearchParams();
+    for (let [key, val] of Object.entries(globals)) {
+        searchParams.append(key, JSON.stringify(val));
+    }
+    if (window.history.pushState && ("" + searchParams).length > 0) {
+        const newurl =
+            location.protocol +
+            "//" +
+            location.host +
+            location.pathname +
+            "?" +
+            searchParams;
+        if (newurl !== "" + location) {
+            window.history.pushState({ path: newurl }, "", newurl);
+        }
+    }
+    return { type: "SET_GLOBALS", payload: globals };
+}

--- a/frontend/src/views/globals/constants.js
+++ b/frontend/src/views/globals/constants.js
@@ -1,0 +1,1 @@
+export const SET_GLOBALS = "SET_GLOBALS";

--- a/frontend/src/views/globals/reducers.js
+++ b/frontend/src/views/globals/reducers.js
@@ -1,0 +1,11 @@
+import { createReducer } from "redux-create-reducer";
+import { SET_GLOBALS } from "./constants";
+
+export const globalReducer = createReducer(
+    {},
+    {
+        [SET_GLOBALS]: (state, action) => ({
+            ...action.payload
+        })
+    }
+);


### PR DESCRIPTION
New "global" UI variables can now be stored in the URL as a search string. This PR stores the active session and the mockAPI state. This allows a page to be refreshed and the same data will get re-fetched, which makes debugging easier.