### PR TITLE
Added `instructors` and `positions` to the mockAPI

### DIFF
--- a/api/app/controllers/api/v1/instructors_controller.rb
+++ b/api/app/controllers/api/v1/instructors_controller.rb
@@ -57,7 +57,7 @@ module Api::V1
             end
         end
 
-        # POST /session/:id/instructors/delete
+        # POST /sessions/:id/instructors/delete
         def delete_instructor_by_session
             # delete an instructor from session is essentially remove
             # the instructor from the all positions of that session
@@ -72,6 +72,29 @@ module Api::V1
             end
             instructor.positions = instructor.positions.except(
                 instructor.positions.select { |x| x.session_id == params[:session_id] }
+            )
+            if instructor.save!
+                render_success(instructor)
+            else
+                render_error(instructor.errors)
+            end
+        end
+
+        # POST /positions/:id/instructors/delete
+        def delete_instructor_by_position
+            # delete an instructor from session is essentially remove
+            # the instructor from the all positions of that session
+            params.require(:id)
+            params.require(:position_id)
+            instructor = Instructor.find(params[:id])
+            instructor.positions.each do |position|
+                if position.id == params[:position_id]
+                    position.instructors = position.instructors.except(params[:id])
+                    position.save!
+                end
+            end
+            instructor.positions = instructor.positions.except(
+                instructor.positions.select { |x| x.id == params[:position_id] }
             )
             if instructor.save!
                 render_success(instructor)

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
                 resources :instructors, only: [:index]
                 resources :assignments, only: [:index, :create]
                 post '/add_instructor', to: 'instructors#create'
+                post '/instructors/delete', to: 'instructors#delete_instructor_by_position'
             end
 
             # applicant routes
@@ -53,7 +54,6 @@ Rails.application.routes.draw do
                 resources :instructors, only: [:index]
                 post '/add_position_template', to: 'position_templates#create'
                 get '/instructors', to: 'instructors#instructor_by_session'
-                post '/instructors/delete', to: 'instructors#delete_instructor_by_session'
             end
 
             # position_template routes

--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -371,6 +371,10 @@ function positionsTests(api = { apiGET, apiPOST }) {
         expect(resp2.payload).toContainObject(newData);
     });
 
+    it.todo("error when updating a position to have an empty position_code");
+
+    it.todo("error when creating a position for a session with an invalid id");
+
     it("error when creating two positions with the same position_code in the same session", async () => {
         // we already have a position
         const resp1 = await apiPOST(
@@ -379,6 +383,21 @@ function positionsTests(api = { apiGET, apiPOST }) {
         );
         expect(resp1).toMatchObject({ status: "error" });
         checkPropTypes(errorPropTypes, resp1);
+    });
+
+    it("error when creating a positions with blank position_code or position_title", async () => {
+        // we already have a position
+        const resp1 = await apiPOST(`/sessions/${session.id}/positions`, {
+            ...newPositionData,
+            position_code: ""
+        });
+        checkPropTypes(errorPropTypes, resp1);
+        const resp2 = await apiPOST(`/sessions/${session.id}/positions`, {
+            ...newPositionData,
+            position_code: "MY UNIQUE CODE XXX",
+            position_title: null
+        });
+        checkPropTypes(errorPropTypes, resp2);
     });
 
     it("succeed when creating two positions with the same code but for different sessions", async () => {
@@ -425,9 +444,7 @@ function positionsTests(api = { apiGET, apiPOST }) {
         expect(resp2.payload).not.toContainObject(position);
     });
 }
-// XXX we need to ignore eslint until we write some
-// actual tests that use `apiGET` and `apiPOST`
-// eslint-disable-next-line
+
 function instructorsTests({ apiGET, apiPOST }) {
     let session = null,
         position = null,
@@ -473,7 +490,7 @@ function instructorsTests({ apiGET, apiPOST }) {
     });
 
     it("get instructors for position", async () => {
-        const resp = await apiGET(`/sessions/${position.id}/instructors`);
+        const resp = await apiGET(`/positions/${position.id}/instructors`);
         expect(resp).toMatchObject({ status: "success" });
         checkPropTypes(PropTypes.arrayOf(instructorPropTypes), resp.payload);
     });
@@ -501,13 +518,13 @@ function instructorsTests({ apiGET, apiPOST }) {
 
     it("delete instructor from position", async () => {
         const resp1 = await apiPOST(
-            `/sessions/${position.id}/instructors/delete`,
+            `/positions/${position.id}/instructors/delete`,
             instructor
         );
         expect(resp1).toMatchObject({ status: "success" });
 
         // make sure instructor is not in the position
-        const resp2 = await apiGET(`/sessions/${position.id}/instructors`);
+        const resp2 = await apiGET(`/positions/${position.id}/instructors`);
         expect(resp2).toMatchObject({ status: "success" });
         checkPropTypes(PropTypes.arrayOf(instructorPropTypes), resp2.payload);
         expect(resp2.payload).not.toContainObject(instructor);
@@ -527,6 +544,8 @@ function instructorsTests({ apiGET, apiPOST }) {
         checkPropTypes(PropTypes.arrayOf(instructorPropTypes), resp2.payload);
         expect(resp2).not.toContainObject(instructor);
     });
+
+    it.todo("fail to delete instructor from a position with invalid id");
 }
 // XXX we need to ignore eslint until we write some
 // actual tests that use `apiGET` and `apiPOST`
@@ -623,7 +642,13 @@ describe("Mock API tests", () => {
     describe("`/sessions` tests", () => {
         sessionsTests(mockAPI);
     });
+    describe("template tests", () => {
+        templateTests(mockAPI);
+    });
+    describe("`/positions` tests", () => {
+        positionsTests(mockAPI);
+    });
     describe("`/instructors` tests", () => {
-        //instructorsTests(mockAPI);
+        instructorsTests(mockAPI);
     });
 });

--- a/frontend/src/api/mockAPI/data.js
+++ b/frontend/src/api/mockAPI/data.js
@@ -26,15 +26,21 @@ export const mockData = {
     ],
     position_templates_by_session: {
         1: [
-            { position_type: "standard", offer_template: "/math/default.html" },
-            { position_type: "oto", offer_template: "/math/oto.html" }
+            {
+                id: 1,
+                position_type: "standard",
+                offer_template: "/math/default.html"
+            },
+            { id: 2, position_type: "oto", offer_template: "/math/oto.html" }
         ],
         2: [
             {
+                id: 3,
                 position_type: "standard",
                 offer_template: "/math/default2018.html"
             },
             {
+                id: 4,
                 position_type: "invigilate",
                 offer_template: "/math/invigilate.html"
             }
@@ -70,62 +76,62 @@ export const mockData = {
             utorid: "beeral"
         }
     ],
-    positions: {
-        1: [
-            {
-                id: 10,
-                position_code: "MAT135H1F",
-                position_title: "Calculus I",
-                est_hours_per_assignment: 70,
-                est_start_date: "2019-09-08T00:00:00.000Z",
-                est_end_date: "2019-12-31T00:00:00.000Z",
-                position_type: "standard",
-                duties: "Tutorials",
-                qualifications: "Teaching skill",
-                ad_hours_per_assignment: 70,
-                ad_num_assignments: 15,
-                ad_open_date: "2019-08-01T00:00:00.000Z",
-                ad_close_date: "2019-08-15T00:00:00.000Z",
-                desired_num_assignments: 15,
-                current_enrollment: 1200,
-                current_waitlisted: 200,
-                instructors: ["smithh", "garciae"]
-            },
-            {
-                id: 11,
-                position_code: "MAT136H1F",
-                position_title: "Calculus II",
-                est_hours_per_assignment: 70,
-                est_start_date: "2019-09-08T00:00:00.000Z",
-                est_end_date: "2019-12-31T00:00:00.000Z",
-                position_type: "invigilation",
-                instructors: []
-            }
-        ],
-        2: [
-            {
-                id: 12,
-                position_code: "CSC135H1F",
-                position_title: "Computer Fun",
-                est_hours_per_assignment: 70,
-                est_start_date: "2019-09-08T00:00:00.000Z",
-                est_end_date: "2019-12-31T00:00:00.000Z",
-                position_type: "standard",
-                duties: "Tutorials",
-                instructors: ["smithh"]
-            },
-            {
-                id: 13,
-                position_code: "MAT235H1F",
-                position_title: "Calculus III",
-                est_hours_per_assignment: 70,
-                est_start_date: "2019-09-08T00:00:00.000Z",
-                est_end_date: "2019-12-31T00:00:00.000Z",
-                position_type: "invigilation",
-                instructors: ["millerm"]
-            }
-        ]
+    positions_by_session: {
+        1: [10, 11],
+        2: [12, 13]
     },
+    positions: [
+        {
+            id: 10,
+            position_code: "MAT135H1F",
+            position_title: "Calculus I",
+            est_hours_per_assignment: 70,
+            est_start_date: "2019-09-08T00:00:00.000Z",
+            est_end_date: "2019-12-31T00:00:00.000Z",
+            position_type: "standard",
+            duties: "Tutorials",
+            qualifications: "Teaching skill",
+            ad_hours_per_assignment: 70,
+            ad_num_assignments: 15,
+            ad_open_date: "2019-08-01T00:00:00.000Z",
+            ad_close_date: "2019-08-15T00:00:00.000Z",
+            desired_num_assignments: 15,
+            current_enrollment: 1200,
+            current_waitlisted: 200,
+            instructors: ["smithh", "garciae"]
+        },
+        {
+            id: 11,
+            position_code: "MAT136H1F",
+            position_title: "Calculus II",
+            est_hours_per_assignment: 70,
+            est_start_date: "2019-09-08T00:00:00.000Z",
+            est_end_date: "2019-12-31T00:00:00.000Z",
+            position_type: "invigilation",
+            instructors: []
+        },
+        {
+            id: 12,
+            position_code: "CSC135H1F",
+            position_title: "Computer Fun",
+            est_hours_per_assignment: 70,
+            est_start_date: "2019-09-08T00:00:00.000Z",
+            est_end_date: "2019-12-31T00:00:00.000Z",
+            position_type: "standard",
+            duties: "Tutorials",
+            instructors: ["smithh"]
+        },
+        {
+            id: 13,
+            position_code: "MAT235H1F",
+            position_title: "Calculus III",
+            est_hours_per_assignment: 70,
+            est_start_date: "2019-09-08T00:00:00.000Z",
+            est_end_date: "2019-12-31T00:00:00.000Z",
+            position_type: "invigilation",
+            instructors: ["millerm"]
+        }
+    ],
     applicants_by_session: {
         1: ["weasleyr", "potterh", "smithb", "howeyb", "brownd"],
         2: ["smithb", "wilsonh", "molinat"]

--- a/frontend/src/api/mockAPI/index.js
+++ b/frontend/src/api/mockAPI/index.js
@@ -1,6 +1,9 @@
 import Route from "route-parser";
 import { mockData } from "./data";
 import { sessionsRoutes } from "./sessions";
+import { templatesRoutes } from "./position_templates";
+import { positionsRoutes } from "./positions";
+import { instructorsRoutes } from "./instructors";
 
 /**
  * Mock API server that runs locally; useuful for demo purposes.
@@ -27,79 +30,30 @@ function pickFromArray(array, id, key = "id") {
 export class MockAPI {
     routePrefix = "/api/v1";
     // a list of selectors for each route
-    getRoutes = Object.assign({}, sessionsRoutes.get, {
-        "/all_data": data => data,
-        "/instructors": data => data.instructors,
-        "/available_position_templates": data => [
-            ...data.available_position_templates
-        ],
-        "/sessions/:session_id/positions": (data, params) => [
-            ...data.positions[params.session_id]
-        ],
-        "/sessions/:session_id/assignments": (data, params) => [
-            ...data.assignments[params.session_id]
-        ],
-        "/sessions/:session_id/position_templates": (data, params) => [
-            ...data.position_templates_by_session[params.session_id]
-        ],
-        "/sessions/:session_id/applicants": (data, params) =>
-            data.applicants_by_session[params.session_id].map(utorid =>
-                pickFromArray(data.applicants, utorid, "utorid")
-            )
-    });
-    postRoutes = Object.assign({}, sessionsRoutes.post, {
-        "/instructors": (data, params, body) => {
-            // body should be an instructor object. If it contains an id,
-            // update an existing session. Otherwise, create a new one.
-            const matchingInstructors = data.instructors.filter(
-                s => s.id === body.id
-            );
-            if (matchingInstructors.length > 0) {
-                return Object.assign(matchingInstructors[0], body);
-            }
-            // if we're here, we need to create a new instructor
-            // but check if the name is empty
-            if (
-                (body.first_name == null || body.first_name === "") &&
-                (body.last_name == null || body.last_name === "")
-            ) {
-                throw new Error("Instructor name cannot be empty!");
-            }
-            if (
-                data.instructors.some(
-                    s =>
-                        (body.utorid && body.utorid === s.utorid) ||
-                        (s.first_name === body.first_name &&
-                            s.last_name === body.last_name)
+    getRoutes = Object.assign(
+        {},
+        sessionsRoutes.get,
+        templatesRoutes.get,
+        positionsRoutes.get,
+        instructorsRoutes.get,
+        {
+            "/all_data": data => data,
+            "/sessions/:session_id/assignments": (data, params) => [
+                ...data.assignments[params.session_id]
+            ],
+            "/sessions/:session_id/applicants": (data, params) =>
+                data.applicants_by_session[params.session_id].map(utorid =>
+                    pickFromArray(data.applicants, utorid, "utorid")
                 )
-            ) {
-                throw new Error(
-                    `Instructor of same first_name=${body.first_name} last_name=${body.last_name} already exists!`
-                );
-            }
-            // create new instructor
-            const newId = Math.floor(Math.random() * 1000);
-            const newInstructor = { ...body, id: newId };
-            data.instructors.push(newInstructor);
-            return newInstructor;
-        },
-        "/instructors/delete": (data, params, body) => {
-            const matchingInstructors = data.instructors.filter(
-                s => s.id === body.id
-            );
-            if (matchingInstructors.length === 0) {
-                throw new Error(
-                    `Could not find instructor with id=${body.id} to delete`
-                );
-            }
-            // if we found the item with matching id, delete it.
-            data.instructors.splice(
-                data.instructors.indexOf(matchingInstructors[0]),
-                1
-            );
-            return matchingInstructors[0];
         }
-    });
+    );
+    postRoutes = Object.assign(
+        {},
+        sessionsRoutes.post,
+        templatesRoutes.post,
+        positionsRoutes.post,
+        instructorsRoutes.post
+    );
 
     constructor(seedData) {
         this.active = false;

--- a/frontend/src/api/mockAPI/instructors.js
+++ b/frontend/src/api/mockAPI/instructors.js
@@ -1,0 +1,116 @@
+import {
+    getUnusedId,
+    find,
+    getAttributesCheckMessage,
+    deleteInArray,
+    findAllById
+} from "./utils";
+
+export const instructorsRoutes = {
+    get: {
+        "/instructors": data => data.instructors,
+        "/positions/:position_id/instructors": (data, params) => {
+            const { position_id } = params;
+            return [
+                ...(data.positions[position_id] || { instructors: [] })
+                    .instructors
+            ];
+        }
+    },
+    post: {
+        "/sessions/:session_id/positions": (data, params, body) => {
+            const { session_id } = params;
+            const positions = data.positions;
+            // Get the appropriate array; if it doesn't exist, initilize it
+            // to an empty array
+            const positions_by_session = (data.positions_by_session[
+                session_id
+            ] = data.positions_by_session[session_id] || []);
+            // body should be a session object. If it contains an id,
+            // update an existing session. Otherwise, create a new one.
+            const matchingPosition = find(body, positions);
+            if (matchingPosition) {
+                return Object.assign(matchingPosition, body);
+            }
+            // if we're here, we need to create a new session
+            // but check if the session name is empty or duplicate
+            const message = getAttributesCheckMessage(
+                body,
+                findAllById(positions_by_session, positions),
+                {
+                    position_code: { required: true, unique: true },
+                    position_title: { required: true }
+                }
+            );
+            if (message) {
+                throw new Error(message);
+            }
+            // create new session
+            const newId = getUnusedId(positions);
+            const newPosition = { ...body, id: newId };
+            positions.push(newPosition);
+            positions_by_session.push(newId);
+            return newPosition;
+        },
+        "/instructors": (data, params, body) => {
+            const instructors = data.instructors;
+            // body should be an instructor object. If it contains an id,
+            // update an existing instructor. Otherwise, create a new one.
+            const matchingInstructor = find(body, instructors);
+            if (matchingInstructor) {
+                return Object.assign(matchingInstructor, body);
+            }
+
+            // if we're here, we need to create a new session
+            // but check if the session name is empty or duplicate
+            const message = getAttributesCheckMessage(body, instructors, {
+                utorid: { required: true, unique: true },
+                first_name: { required: true },
+                last_name: { required: true }
+            });
+            if (message) {
+                throw new Error(message);
+            }
+            const newId = getUnusedId(instructors);
+            const newInstructor = { ...body, id: newId };
+            instructors.push(newInstructor);
+            return newInstructor;
+        },
+        "/instructors/delete": (data, params, body) => {
+            const instructors = data.instructors;
+            const matchingInstructor = find(body, instructors);
+            if (!matchingInstructor) {
+                throw new Error(
+                    `Could not find instructor with id=${body.id} to delete`
+                );
+            }
+            deleteInArray(matchingInstructor, instructors);
+            // if we found the session with matching id, delete it.
+            return body;
+        },
+        "/positions/:position_id/add_instructor": (data, params, body) => {
+            const { position_id } = params;
+            const instructor = find(body, data.instructors);
+            if (!instructor) {
+                throw new Error(`Cannot find instructor with id=${body.id}`);
+            }
+            const position = find({ id: position_id }, data.positions);
+            const instructors = (position.instructors =
+                position.instructors || []);
+            instructors.push(instructor.utorid);
+            return { ...instructor };
+        },
+        "/positions/:position_id/instructors/delete": (data, params, body) => {
+            const { position_id } = params;
+            const instructor = find(body, data.instructors);
+            if (!instructor) {
+                throw new Error(`Cannot find instructor with id=${body.id}`);
+            }
+            const position = find({ id: position_id }, data.positions);
+            const instructors = (position.instructors =
+                position.instructors || []);
+            deleteInArray(instructor.utorid, instructors);
+            return { ...instructor };
+        }
+    }
+};

--- a/frontend/src/api/mockAPI/position_templates.js
+++ b/frontend/src/api/mockAPI/position_templates.js
@@ -1,0 +1,46 @@
+import { find, getAttributesCheckMessage, getUnusedId } from "./utils";
+
+export const templatesRoutes = {
+    get: {
+        "/available_position_templates": data => [
+            ...data.available_position_templates
+        ],
+        "/sessions/:session_id/position_templates": (data, params) => [
+            ...(data.position_templates_by_session[params.session_id] || [])
+        ]
+    },
+    post: {
+        "/sessions/:session_id/add_position_template": (data, params, body) => {
+            const { session_id } = params;
+            // Get the appropriate array; if it doesn't exist, initilize it
+            // to an empty array
+            const position_templates = (data.position_templates_by_session[
+                session_id
+            ] = data.position_templates_by_session[session_id] || []);
+            const matchingTemplate = find(body, position_templates);
+            if (matchingTemplate) {
+                return Object.assign(matchingTemplate, body);
+            }
+            const message = getAttributesCheckMessage(
+                body,
+                position_templates,
+                {
+                    position_type: { required: true },
+                    offer_template: { required: true }
+                }
+            );
+            if (message) {
+                throw new Error(message);
+            }
+            // create new template
+            const newId = getUnusedId(position_templates);
+            const newTemplate = {
+                id: newId,
+                position_type: body.position_type,
+                offer_template: body.offer_template
+            };
+            position_templates.push(newTemplate);
+            return position_templates;
+        }
+    }
+};

--- a/frontend/src/api/mockAPI/positions.js
+++ b/frontend/src/api/mockAPI/positions.js
@@ -1,0 +1,74 @@
+import {
+    getUnusedId,
+    find,
+    getAttributesCheckMessage,
+    deleteInArray,
+    findAllById
+} from "./utils";
+
+export const positionsRoutes = {
+    get: {
+        "/sessions/:session_id/positions": (data, params) =>
+            findAllById(
+                data.positions_by_session[params.session_id],
+                data.positions
+            )
+    },
+    post: {
+        "/sessions/:session_id/positions": (data, params, body) => {
+            const { session_id } = params;
+            const positions = data.positions;
+            // Get the appropriate array; if it doesn't exist, initilize it
+            // to an empty array
+            const positions_by_session = (data.positions_by_session[
+                session_id
+            ] = data.positions_by_session[session_id] || []);
+            // body should be a session object. If it contains an id,
+            // update an existing session. Otherwise, create a new one.
+            const matchingPosition = find(body, positions);
+            if (matchingPosition) {
+                return Object.assign(matchingPosition, body);
+            }
+            // if we're here, we need to create a new session
+            // but check if the session name is empty or duplicate
+            const message = getAttributesCheckMessage(
+                body,
+                findAllById(positions_by_session, positions),
+                {
+                    position_code: { required: true, unique: true },
+                    position_title: { required: true }
+                }
+            );
+            if (message) {
+                throw new Error(message);
+            }
+            // create new session
+            const newId = getUnusedId(positions);
+            const newPosition = { ...body, id: newId };
+            positions.push(newPosition);
+            positions_by_session.push(newId);
+            return newPosition;
+        },
+        "/positions": (data, params, body) => {
+            const positions = data.positions;
+            // body should be a session object. If it contains an id,
+            // update an existing session. Otherwise, create a new one.
+            const matchingPosition = find(body, positions);
+            if (matchingPosition) {
+                return Object.assign(matchingPosition, body);
+            }
+            throw new Error(`Cannot find position with id=${body.id}`);
+        },
+        "/positions/delete": (data, params, body) => {
+            const positions = data.positions;
+            // body should be a session object. If it contains an id,
+            // update an existing session. Otherwise, create a new one.
+            const matchingPosition = find(body, positions);
+            if (!matchingPosition) {
+                throw new Error(`Cannot find position with id=${body.id}`);
+            }
+            deleteInArray(matchingPosition, positions);
+            return {};
+        }
+    }
+};

--- a/frontend/src/api/mockAPI/utils.js
+++ b/frontend/src/api/mockAPI/utils.js
@@ -12,7 +12,7 @@
  */
 export function getUnusedId(data, prop = "id") {
     const ids = data.map(x => +x[prop]).filter(x => x != null);
-    const max = Math.max(...ids);
+    const max = Math.max(0, ...ids);
     if (isNaN(max)) {
         // Somehow there was some other type mixed in with the ids. In this case,
         // generate a random string
@@ -32,7 +32,24 @@ export function getUnusedId(data, prop = "id") {
  * @returns {undefined|object}
  */
 export function find(obj, data = [], prop = "id") {
-    return data.find(s => s[prop] === obj[prop]);
+    // We really do want to use `==` and not `===` here.
+    // Sometimes ids are given as ints and sometimes as strings;
+    // we should work interchangibly with both.
+    return data.find(s => s[prop] == obj[prop]);
+}
+
+/**
+ * Filter `data` to be a list which only includes items
+ * with ids listed in `ids`.
+ *
+ * @export
+ * @param {*} [ids=[]]
+ * @param {*} [data=[]]
+ * @param {string} [prop="id"]
+ * @returns {object[]}
+ */
+export function findAllById(ids = [], data = [], prop = "id") {
+    return data.filter(x => ids.includes(x[prop]));
 }
 
 /**


### PR DESCRIPTION
This PR also removes the spurious `/sessions/:session_id/instructors/delete` route.