### PR TITLE
Fixed mockAPI to work with swagger

### DIFF
--- a/frontend/src/api/defs/doc-generation.js
+++ b/frontend/src/api/defs/doc-generation.js
@@ -82,6 +82,7 @@ const PROPTYPES_TO_SWAGGER_TYPES = {
 function wrappedPropTypesToSwagger(pt) {
     const ret = {};
     if (!pt.callChain) {
+        // eslint-disable-next-line
         console.warn(
             "Attempting to compute swagger values for non-wrapped object",
             pt
@@ -212,6 +213,7 @@ function documentedCallbackToSwagger(docs, templateVars = []) {
             required: true
         }));
     }
+    // `docs.returns` holds information about what the route will return
     if (docs.returns) {
         ret.responses.default = {
             content: {
@@ -219,6 +221,17 @@ function documentedCallbackToSwagger(docs, templateVars = []) {
                     schema: wrapInStandardApiResponseForSwagger(
                         wrappedPropTypesToSwagger(docs.returns)
                     )
+                }
+            }
+        };
+    }
+    // `docs.posts` holds information about what you can put in the
+    // requestBody
+    if (docs.posts) {
+        ret.requestBody = {
+            content: {
+                "application/json": {
+                    schema: wrappedPropTypesToSwagger(docs.posts)
                 }
             }
         };

--- a/frontend/src/api/defs/prop-types.js
+++ b/frontend/src/api/defs/prop-types.js
@@ -25,6 +25,9 @@ function generatePropTypes(PropTypes) {
             message: PropTypes.string.isRequired,
             payload: PropTypes.any
         }),
+        idOnly: PropTypes.shape({
+            id: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+        }),
         session: PropTypes.shape({
             id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
             start_date: PropTypes.string,

--- a/frontend/src/api/mockAPI/positions.js
+++ b/frontend/src/api/mockAPI/positions.js
@@ -5,70 +5,95 @@ import {
     deleteInArray,
     findAllById
 } from "./utils";
+import {
+    documentCallback,
+    wrappedPropTypes,
+    docApiPropTypes
+} from "../defs/doc-generation";
 
 export const positionsRoutes = {
     get: {
-        "/sessions/:session_id/positions": (data, params) =>
-            findAllById(
-                data.positions_by_session[params.session_id],
-                data.positions
-            )
+        "/sessions/:session_id/positions": documentCallback({
+            func: (data, params) =>
+                findAllById(
+                    data.positions_by_session[params.session_id],
+                    data.positions
+                ),
+            summary: "Get positions associated with this session.",
+            returns: wrappedPropTypes.arrayOf(docApiPropTypes.position)
+        })
     },
     post: {
-        "/sessions/:session_id/positions": (data, params, body) => {
-            const { session_id } = params;
-            const positions = data.positions;
-            // Get the appropriate array; if it doesn't exist, initilize it
-            // to an empty array
-            const positions_by_session = (data.positions_by_session[
-                session_id
-            ] = data.positions_by_session[session_id] || []);
-            // body should be a session object. If it contains an id,
-            // update an existing session. Otherwise, create a new one.
-            const matchingPosition = find(body, positions);
-            if (matchingPosition) {
-                return Object.assign(matchingPosition, body);
-            }
-            // if we're here, we need to create a new session
-            // but check if the session name is empty or duplicate
-            const message = getAttributesCheckMessage(
-                body,
-                findAllById(positions_by_session, positions),
-                {
-                    position_code: { required: true, unique: true },
-                    position_title: { required: true }
+        "/sessions/:session_id/positions": documentCallback({
+            func: (data, params, body) => {
+                const { session_id } = params;
+                const positions = data.positions;
+                // Get the appropriate array; if it doesn't exist, initilize it
+                // to an empty array
+                const positions_by_session = (data.positions_by_session[
+                    session_id
+                ] = data.positions_by_session[session_id] || []);
+                // body should be a session object. If it contains an id,
+                // update an existing session. Otherwise, create a new one.
+                const matchingPosition = find(body, positions);
+                if (matchingPosition) {
+                    return Object.assign(matchingPosition, body);
                 }
-            );
-            if (message) {
-                throw new Error(message);
-            }
-            // create new session
-            const newId = getUnusedId(positions);
-            const newPosition = { ...body, id: newId };
-            positions.push(newPosition);
-            positions_by_session.push(newId);
-            return newPosition;
-        },
-        "/positions": (data, params, body) => {
-            const positions = data.positions;
-            // body should be a session object. If it contains an id,
-            // update an existing session. Otherwise, create a new one.
-            const matchingPosition = find(body, positions);
-            if (matchingPosition) {
-                return Object.assign(matchingPosition, body);
-            }
-            throw new Error(`Cannot find position with id=${body.id}`);
-        },
-        "/positions/delete": (data, params, body) => {
-            const positions = data.positions;
-            // body should be a session object. If it contains an id,
-            // update an existing session. Otherwise, create a new one.
-            const matchingPosition = find(body, positions);
-            if (!matchingPosition) {
+                // if we're here, we need to create a new session
+                // but check if the session name is empty or duplicate
+                const message = getAttributesCheckMessage(
+                    body,
+                    findAllById(positions_by_session, positions),
+                    {
+                        position_code: { required: true, unique: true },
+                        position_title: { required: true }
+                    }
+                );
+                if (message) {
+                    throw new Error(message);
+                }
+                // create new session
+                const newId = getUnusedId(positions);
+                const newPosition = { ...body, id: newId };
+                positions.push(newPosition);
+                positions_by_session.push(newId);
+                return newPosition;
+            },
+            summary:
+                "Upsert a position associated with a session. If a new position is created, it will be automatically associated with the given session",
+            posts: docApiPropTypes.position,
+            returns: docApiPropTypes.position
+        }),
+        "/positions": documentCallback({
+            func: (data, params, body) => {
+                const positions = data.positions;
+                // body should be a session object. If it contains an id,
+                // update an existing session. Otherwise, create a new one.
+                const matchingPosition = find(body, positions);
+                if (matchingPosition) {
+                    return Object.assign(matchingPosition, body);
+                }
                 throw new Error(`Cannot find position with id=${body.id}`);
-            }
-            deleteInArray(matchingPosition, positions);
-            return {};
-        }
+            },
+            summary: "Update a position",
+            posts: docApiPropTypes.position,
+            returns: docApiPropTypes.position
+        }),
+        "/positions/delete": documentCallback({
+            func: (data, params, body) => {
+                const positions = data.positions;
+                // body should be a session object. If it contains an id,
+                // update an existing session. Otherwise, create a new one.
+                const matchingPosition = find(body, positions);
+                if (!matchingPosition) {
+                    throw new Error(`Cannot find position with id=${body.id}`);
+                }
+                deleteInArray(matchingPosition, positions);
+                return {};
+            },
+            summary: "Delete a position",
+            posts: docApiPropTypes.idOnly,
+            returns: docApiPropTypes.session
+        })
     }
 };

--- a/frontend/src/api/mockAPI/sessions.js
+++ b/frontend/src/api/mockAPI/sessions.js
@@ -19,37 +19,47 @@ export const sessionsRoutes = {
         })
     },
     post: {
-        "/sessions": (data, params, body) => {
-            // body should be a session object. If it contains an id,
-            // update an existing session. Otherwise, create a new one.
-            const matchingSession = find(body, data.sessions);
-            if (matchingSession) {
-                return Object.assign(matchingSession, body);
-            }
-            // if we're here, we need to create a new session
-            // but check if the session name is empty or duplicate
-            const message = getAttributesCheckMessage(body, data.sessions, {
-                name: { required: true, unique: true }
-            });
-            if (message) {
-                throw new Error(message);
-            }
-            // create new session
-            const newId = getUnusedId(data.sessions);
-            const newSession = { ...body, id: newId };
-            data.sessions.push(newSession);
-            return newSession;
-        },
-        "/sessions/delete": (data, params, body) => {
-            const matchingSession = find(body, data.sessions);
-            if (!matchingSession) {
-                throw new Error(
-                    `Could not find session with id=${body.id} to delete`
-                );
-            }
-            deleteInArray(matchingSession, data.sessions);
-            // if we found the session with matching id, delete it.
-            return {};
-        }
+        "/sessions": documentCallback({
+            func: (data, params, body) => {
+                // body should be a session object. If it contains an id,
+                // update an existing session. Otherwise, create a new one.
+                const matchingSession = find(body, data.sessions);
+                if (matchingSession) {
+                    return Object.assign(matchingSession, body);
+                }
+                // if we're here, we need to create a new session
+                // but check if the session name is empty or duplicate
+                const message = getAttributesCheckMessage(body, data.sessions, {
+                    name: { required: true, unique: true }
+                });
+                if (message) {
+                    throw new Error(message);
+                }
+                // create new session
+                const newId = getUnusedId(data.sessions);
+                const newSession = { ...body, id: newId };
+                data.sessions.push(newSession);
+                return newSession;
+            },
+            summary: "Upsert a session",
+            returns: docApiPropTypes.session,
+            posts: docApiPropTypes.session
+        }),
+        "/sessions/delete": documentCallback({
+            func: (data, params, body) => {
+                const matchingSession = find(body, data.sessions);
+                if (!matchingSession) {
+                    throw new Error(
+                        `Could not find session with id=${body.id} to delete`
+                    );
+                }
+                deleteInArray(matchingSession, data.sessions);
+                // if we found the session with matching id, delete it.
+                return {};
+            },
+            summary: "Delete a session",
+            posts: docApiPropTypes.idOnly,
+            returns: docApiPropTypes.session
+        })
     }
 };

--- a/frontend/src/views/dev_frame/index.js
+++ b/frontend/src/views/dev_frame/index.js
@@ -42,8 +42,7 @@ const swaggerData = {
             "TAPP is a program for TA management--for making TA assignments and distributing TA contracts.",
         title: "TAPP"
     },
-    host: "localhost:8000",
-    basePath: "/v1/api",
+    servers: [{ url: "/api/v1" }],
     paths: {
         /* XXX this is hear temporarily to serve as an example for generating Swagger (openapi) documenation
         "/bob": {


### PR DESCRIPTION
Return a `new Request()` instead of just an `Object`. This matches the behavior of `fetch`.