### PR TITLE
API enable unit tests

### DIFF
--- a/api/app/controllers/api/v1/admin/contract_templates_controller.rb
+++ b/api/app/controllers/api/v1/admin/contract_templates_controller.rb
@@ -4,14 +4,14 @@
 class Api::V1::Admin::ContractTemplatesController < ApplicationController
     # GET /contract_templates
     def index
-        render_success ContractTemplate.by_session(params[:id])
+        render_success ContractTemplate.by_session(params[:session_id])
     end
 
     # POST /contract_templates
     def create
-        @session = Session.find(params[:id])
-        @session.contract_template.new(contract_template_create_params)
-        render_on_condition(object: @session, condition: proc { @session.save! })
+        @session = Session.find(params[:session_id])
+        template = @session.contract_templates.new(contract_template_create_params)
+        render_on_condition(object: template, condition: proc { template.save! })
     end
 
     # GET /available_contract_templates
@@ -28,6 +28,6 @@ class Api::V1::Admin::ContractTemplatesController < ApplicationController
     private
 
     def contract_template_create_params
-        params.permit(:template_file, :template_name)
+        params.permit(:template_file, :template_name, :session_id)
     end
 end

--- a/api/app/controllers/api/v1/admin/debug_controller.rb
+++ b/api/app/controllers/api/v1/admin/debug_controller.rb
@@ -17,21 +17,25 @@ class Api::V1::Admin::DebugController < ApplicationController
     # POST /snapshot
     def snapshot
         Rake::Task['debug:snapshot'].execute
+        render_success
     end
 
     # POST /clear_data
     def clear_data
         Rake::Task['db:schema:load'].execute
+        render_success
     end
 
     # POST /restore_snapshot
     def restore_snapshot
         Rake::Task['debug:restore'].execute
+        render_success
     end
 
     private
 
     def active_user_create_params
         params.permit(credentials: {})
+        render_success
     end
 end

--- a/api/app/models/session.rb
+++ b/api/app/models/session.rb
@@ -8,6 +8,7 @@ class Session < ApplicationRecord
 
     validates :rate1, numericality: { only_float: true }, allow_nil: true
     validates :rate2, numericality: { only_float: true }, allow_nil: true
+    validates :name, presence: true
     validates_uniqueness_of :name
 end
 

--- a/api/app/serializers/contract_template_serializer.rb
+++ b/api/app/serializers/contract_template_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class ContractTemplateSerializer < ActiveModel::Serializer
-    attributes :id, :template_file
+    attributes :id, :template_file, :template_name
 end

--- a/api/app/serializers/session_serializer.rb
+++ b/api/app/serializers/session_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class SessionSerializer < ActiveModel::Serializer
-    attributes :id, :start_date, :end_date, :name
+    attributes :id, :start_date, :end_date, :name, :rate1, :rate2
 end

--- a/api/docs/erd.svg
+++ b/api/docs/erd.svg
@@ -73,7 +73,7 @@
 <text text-anchor="start" x="676" y="-635.5" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
 </g>
 <!-- m_Applicant&#45;&gt;m_ApplicantDataForMatching -->
-<g id="edge18" class="edge">
+<g id="edge10" class="edge">
 <title>m_Applicant&#45;&gt;m_ApplicantDataForMatching</title>
 <path fill="none" stroke="#000000" d="M486.5,-603.5C531.5762,-603.8986 578.9714,-620.077 616.9708,-637.4035"/>
 </g>
@@ -91,7 +91,7 @@
 <text text-anchor="start" x="470.5" y="-398.5" font-family="Arial Italic" font-size="10.00" fill="#999999">text</text>
 </g>
 <!-- m_Applicant&#45;&gt;m_Application -->
-<g id="edge15" class="edge">
+<g id="edge19" class="edge">
 <title>m_Applicant&#45;&gt;m_Application</title>
 <path fill="none" stroke="#000000" d="M350.0242,-546.4324C379.4697,-519.909 414.3422,-488.4971 441.4657,-464.0653"/>
 <polygon fill="#000000" stroke="#000000" points="443.6076,-466.3754 448.1865,-458.0114 439.3911,-461.6944 443.6076,-466.3754"/>
@@ -120,14 +120,14 @@
 <text text-anchor="start" x="695" y="-471.5" font-family="Arial Italic" font-size="10.00" fill="#999999">integer (8) FK</text>
 </g>
 <!-- m_Applicant&#45;&gt;m_Assignment -->
-<g id="edge13" class="edge">
+<g id="edge17" class="edge">
 <title>m_Applicant&#45;&gt;m_Assignment</title>
 <path fill="none" stroke="#000000" d="M362.3228,-601.8261C399.4431,-602.4504 445.3887,-603.1364 486.5,-603.5"/>
 <path fill="none" stroke="#000000" d="M486.5,-603.5C529.7597,-603.8826 575.222,-589.2039 612.4433,-572.7347"/>
 <polygon fill="#000000" stroke="#000000" points="613.8457,-575.5576 620.7426,-568.973 611.2449,-569.8195 613.8457,-575.5576"/>
 </g>
 <!-- m_Application&#45;&gt;m_ApplicantDataForMatching -->
-<g id="edge19" class="edge">
+<g id="edge11" class="edge">
 <title>m_Application&#45;&gt;m_ApplicantDataForMatching</title>
 <path fill="none" stroke="#000000" d="M505.644,-458.333C528.0779,-497.5415 567.7265,-562.0803 611,-610.5 613.5106,-613.3092 616.1372,-616.1057 618.8455,-618.874"/>
 <polygon fill="#000000" stroke="#000000" points="616.6897,-621.1725 625.2976,-625.2747 621.1267,-616.6999 616.6897,-621.1725"/>
@@ -146,7 +146,7 @@
 <text text-anchor="start" x="702" y="-372.5" font-family="Arial Italic" font-size="10.00" fill="#999999">integer</text>
 </g>
 <!-- m_Application&#45;&gt;m_PositionPreference -->
-<g id="edge14" class="edge">
+<g id="edge15" class="edge">
 <title>m_Application&#45;&gt;m_PositionPreference</title>
 <path fill="none" stroke="#000000" d="M558.7237,-414.4065C575.4063,-412.306 593.2803,-410.0555 610.3687,-407.9039"/>
 <polygon fill="#000000" stroke="#000000" points="611.233,-410.9701 619.7689,-406.7204 610.4459,-404.7194 611.233,-410.9701"/>
@@ -230,7 +230,7 @@
 <text text-anchor="start" x="861" y="-260.5" font-family="Arial Italic" font-size="10.00" fill="#999999">datetime</text>
 </g>
 <!-- m_Assignment&#45;&gt;m_WageChunk -->
-<g id="edge3" class="edge">
+<g id="edge16" class="edge">
 <title>m_Assignment&#45;&gt;m_WageChunk</title>
 <path fill="none" stroke="#000000" d="M763.9936,-461.3249C767.9141,-456.4695 771.6246,-451.5086 775,-446.5 797.928,-412.4784 786.6185,-394.4955 811,-361.5 813.0938,-358.6664 815.34,-355.8789 817.7001,-353.1484"/>
 <polygon fill="#000000" stroke="#000000" points="820.4338,-354.8273 824.1873,-346.0618 815.7868,-350.5734 820.4338,-354.8273"/>
@@ -270,7 +270,7 @@
 <text text-anchor="start" x="499.5" y="-247.5" font-family="Arial Italic" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
 </g>
 <!-- m_ContractTemplate&#45;&gt;m_Position -->
-<g id="edge11" class="edge">
+<g id="edge9" class="edge">
 <title>m_ContractTemplate&#45;&gt;m_Position</title>
 <path fill="none" stroke="#000000" d="M362.0536,-256.0679C370.8522,-259.0679 379.9531,-262.171 389.045,-265.2711"/>
 <polygon fill="#000000" stroke="#000000" points="388.214,-268.3157 397.7491,-268.2389 390.2472,-262.3528 388.214,-268.3157"/>
@@ -291,14 +291,14 @@
 <text text-anchor="start" x="253" y="-306.5" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗ U</text>
 </g>
 <!-- m_Instructor&#45;&gt;m_Position -->
-<g id="edge4" class="edge">
+<g id="edge1" class="edge">
 <title>m_Instructor&#45;&gt;m_Position</title>
 <path fill="none" stroke="#000000" d="M371.1263,-321.3986C376.8904,-320.2546 382.7356,-319.0945 388.5793,-317.9346"/>
 <polygon fill="#000000" stroke="#000000" points="370.2681,-318.3574 362.0536,-323.1993 371.4946,-324.5369 370.2681,-318.3574"/>
 <polygon fill="#000000" stroke="#000000" points="389.5345,-320.9566 397.7491,-316.1147 388.308,-314.7771 389.5345,-320.9566"/>
 </g>
 <!-- m_Position&#45;&gt;m_Assignment -->
-<g id="edge6" class="edge">
+<g id="edge3" class="edge">
 <title>m_Position&#45;&gt;m_Assignment</title>
 <path fill="none" stroke="#000000" d="M561.6101,-359.0408C566.3681,-364.0562 570.8894,-369.2303 575,-374.5 597.0045,-402.7099 590.0808,-417.4761 611,-446.5 612.7658,-448.9499 614.6062,-451.3942 616.5063,-453.8252"/>
 <polygon fill="#000000" stroke="#000000" points="614.2603,-456.0572 622.3714,-461.0705 619.157,-452.0932 614.2603,-456.0572"/>
@@ -325,7 +325,7 @@
 <text text-anchor="start" x="692" y="-122.5" font-family="Arial Italic" font-size="10.00" fill="#999999">datetime</text>
 </g>
 <!-- m_Position&#45;&gt;m_PositionDataForAd -->
-<g id="edge1" class="edge">
+<g id="edge6" class="edge">
 <title>m_Position&#45;&gt;m_PositionDataForAd</title>
 <path fill="none" stroke="#000000" d="M575.273,-244.7633C589.2651,-236.2935 603.6192,-227.6046 617.2796,-219.3356"/>
 </g>
@@ -345,12 +345,12 @@
 <text text-anchor="start" x="697" y="-10.5" font-family="Arial Italic" font-size="10.00" fill="#999999">integer</text>
 </g>
 <!-- m_Position&#45;&gt;m_PositionDataForMatching -->
-<g id="edge9" class="edge">
+<g id="edge7" class="edge">
 <title>m_Position&#45;&gt;m_PositionDataForMatching</title>
 <path fill="none" stroke="#000000" d="M515.5564,-237.6733C537.7704,-195.2513 571.2813,-139.0313 611,-97.5 616.0043,-92.2673 621.5737,-87.2443 627.3881,-82.503"/>
 </g>
 <!-- m_Position&#45;&gt;m_PositionPreference -->
-<g id="edge7" class="edge">
+<g id="edge4" class="edge">
 <title>m_Position&#45;&gt;m_PositionPreference</title>
 <path fill="none" stroke="#000000" d="M575.273,-341.0595C587.6186,-346.9782 600.2459,-353.0319 612.43,-358.8732"/>
 <polygon fill="#000000" stroke="#000000" points="611.308,-361.8286 620.7854,-362.8789 614.0316,-356.1477 611.308,-361.8286"/>
@@ -369,14 +369,14 @@
 <text text-anchor="start" x="652" y="-273.5" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
 </g>
 <!-- m_Position&#45;&gt;m_ReportingTag -->
-<g id="edge5" class="edge">
+<g id="edge2" class="edge">
 <title>m_Position&#45;&gt;m_ReportingTag</title>
 <path fill="none" stroke="#000000" d="M584.2794,-298.5C591.8425,-298.5 599.4448,-298.5 606.9234,-298.5"/>
 <polygon fill="#000000" stroke="#000000" points="584.273,-295.3501 575.273,-298.5 584.273,-301.6501 584.273,-295.3501"/>
 <polygon fill="#000000" stroke="#000000" points="607.318,-301.6501 616.318,-298.5 607.3179,-295.3501 607.318,-301.6501"/>
 </g>
 <!-- m_ReportingTag&#45;&gt;m_WageChunk -->
-<g id="edge2" class="edge">
+<g id="edge18" class="edge">
 <title>m_ReportingTag&#45;&gt;m_WageChunk</title>
 <path fill="none" stroke="#000000" d="M778.8551,-298.5C786.3422,-298.5 793.9157,-298.5 801.3926,-298.5"/>
 <polygon fill="#000000" stroke="#000000" points="778.5559,-295.3501 769.5559,-298.5 778.5559,-301.6501 778.5559,-295.3501"/>
@@ -400,19 +400,19 @@
 <text text-anchor="start" x="51" y="-289.5" font-family="Arial Italic" font-size="10.00" fill="#999999">float</text>
 </g>
 <!-- m_Session&#45;&gt;m_Application -->
-<g id="edge16" class="edge">
+<g id="edge13" class="edge">
 <title>m_Session&#45;&gt;m_Application</title>
 <path fill="none" stroke="#000000" d="M290,-423.5C327.6415,-426.1682 369.4409,-426.5306 404.7773,-426.0816"/>
 <polygon fill="#000000" stroke="#000000" points="405.136,-429.2267 414.0881,-425.9429 405.0421,-422.9274 405.136,-429.2267"/>
 </g>
 <!-- m_Session&#45;&gt;m_ContractTemplate -->
-<g id="edge17" class="edge">
+<g id="edge14" class="edge">
 <title>m_Session&#45;&gt;m_ContractTemplate</title>
 <path fill="none" stroke="#000000" d="M163.1249,-292.7061C178.3288,-285.3715 194.4575,-277.5909 209.9334,-270.1251"/>
 <polygon fill="#000000" stroke="#000000" points="211.7167,-272.7623 218.454,-266.0146 208.9793,-267.088 211.7167,-272.7623"/>
 </g>
 <!-- m_Session&#45;&gt;m_Position -->
-<g id="edge10" class="edge">
+<g id="edge8" class="edge">
 <title>m_Session&#45;&gt;m_Position</title>
 <path fill="none" stroke="#000000" d="M157.3195,-375.0668C194.3825,-397.5083 242.5543,-420.1369 290,-423.5"/>
 <path fill="none" stroke="#000000" d="M290,-423.5C315.258,-425.2904 362.8397,-395.4053 404.8538,-364.412"/>

--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -68,7 +68,8 @@ function sessionsTests(api = { apiGET, apiPOST }) {
 
     beforeAll(async () => {
         await apiPOST("/admin/debug/snapshot");
-    });
+        await apiPOST("/admin/debug/clear_data");
+    }, 15000);
     afterAll(async () => {
         await apiPOST("/admin/debug/restore_snapshot");
     });
@@ -143,50 +144,51 @@ function sessionsTests(api = { apiGET, apiPOST }) {
         checkPropTypes(errorPropTypes, resp2);
     });
 
-    //    it("throw error when `name` is not unique", async () => {
-    //        // name identical to the exisiting session
-    //        const newData = { ...newSessionData, name: session.name };
-    //        // POST to create new session
-    //        const resp1 = await apiPOST("/sessions", newData);
-    //
-    //        // expected an error as name not unique
-    //        expect(resp1).toMatchObject({ status: "error" });
-    //        checkPropTypes(errorPropTypes, resp1);
-    //    });
-    //
-    //    it("throw error when deleting item with invalid id", async () => {
-    //        // get the max session id
-    //        const resp1 = await apiGET("/sessions");
-    //        expect(resp1).toMatchObject({ status: "success" });
-    //        checkPropTypes(PropTypes.arrayOf(sessionPropTypes), resp1.payload);
-    //        const maxId = Math.max(...resp1.payload.map(s => s.id));
-    //
-    //        // delete with non-existing id
-    //        const resp2 = await apiPOST("/sessions/delete", {
-    //            id: maxId + 1 // add 1 to make the id invalid
-    //        });
-    //        // expected an error with non-identical session id
-    //        expect(resp2).toMatchObject({ status: "error" });
-    //        checkPropTypes(errorPropTypes, resp2);
-    //
-    //        // delete with id = null
-    //        const resp3 = await apiPOST("/sessions/delete", {
-    //            id: null
-    //        });
-    //        // expected an error with non-identical session id
-    //        expect(resp3).toMatchObject({ status: "error" });
-    //        checkPropTypes(errorPropTypes, resp3);
-    //    });
-    //
-    //    it("delete session", async () => {
-    //        const resp1 = await apiPOST("/sessions/delete", {
-    //            id: session.id
-    //        });
-    //        expect(resp1).toMatchObject({ status: "success" });
-    //        const { payload: withoutNewSessions } = await apiGET("/sessions");
-    //        expect(withoutNewSessions.map(x => x.id)).not.toContain(session.id);
-    //    });
+    it("throw error when `name` is not unique", async () => {
+        // name identical to the exisiting session
+        const newData = { ...newSessionData, name: session.name };
+        // POST to create new session
+        const resp1 = await apiPOST("/admin/sessions", newData);
+
+        // expected an error as name not unique
+        expect(resp1).toMatchObject({ status: "error" });
+        checkPropTypes(errorPropTypes, resp1);
+    });
+
+    it("throw error when deleting item with invalid id", async () => {
+        // get the max session id
+        const resp1 = await apiGET("/admin/sessions");
+        expect(resp1).toMatchObject({ status: "success" });
+        checkPropTypes(PropTypes.arrayOf(sessionPropTypes), resp1.payload);
+        const maxId = Math.max(...resp1.payload.map(s => s.id));
+
+        // delete with non-existing id
+        const resp2 = await apiPOST("/admin/sessions/delete", {
+            id: maxId + 1 // add 1 to make the id invalid
+        });
+        // expected an error with non-identical session id
+        expect(resp2).toMatchObject({ status: "error" });
+        checkPropTypes(errorPropTypes, resp2);
+
+        // delete with id = null
+        const resp3 = await apiPOST("/admin/sessions/delete", {
+            id: null
+        });
+        // expected an error with non-identical session id
+        expect(resp3).toMatchObject({ status: "error" });
+        checkPropTypes(errorPropTypes, resp3);
+    });
+
+    it("delete session", async () => {
+        const resp1 = await apiPOST("/admin/sessions/delete", {
+            id: session.id
+        });
+        expect(resp1).toMatchObject({ status: "success" });
+        const { payload: withoutNewSessions } = await apiGET("/admin/sessions");
+        expect(withoutNewSessions.map(x => x.id)).not.toContain(session.id);
+    });
 }
+
 function templateTests(api = { apiGET, apiPOST }) {
     const { apiGET, apiPOST } = api;
     let session = null,
@@ -202,16 +204,18 @@ function templateTests(api = { apiGET, apiPOST }) {
     };
     // set up a session to be available before tests run
     beforeAll(async () => {
+        await apiPOST("/admin/debug/snapshot");
+        //await apiPOST("/admin/debug/clear_data");
         // this session will be available for all tests
         session = await addSession({ apiGET, apiPOST });
-    });
+    }, 15000);
     // delete the session after the tests run
     afterAll(async () => {
-        await deleteSession({ apiGET, apiPOST }, session);
+        await apiPOST("/admin/debug/restore_snapshot");
     });
 
     it("fetch available templates", async () => {
-        const resp = await apiGET("/available_contract_templates");
+        const resp = await apiGET("/admin/available_contract_templates");
         expect(resp).toMatchObject({ status: "success" });
         checkPropTypes(
             PropTypes.arrayOf(offerTemplateMinimalPropTypes),
@@ -223,7 +227,7 @@ function templateTests(api = { apiGET, apiPOST }) {
         // grab the contract_templates of the new session. They may have
         // pre-populated.
         const resp1 = await apiGET(
-            `/sessions/${session.id}/contract_templates`
+            `/admin/sessions/${session.id}/contract_templates`
         );
         expect(resp1).toMatchObject({ status: "success" });
         checkPropTypes(
@@ -233,7 +237,7 @@ function templateTests(api = { apiGET, apiPOST }) {
 
         // add the new offer template
         const resp2 = await apiPOST(
-            `/sessions/${session.id}/contract_templates`,
+            `/admin/sessions/${session.id}/contract_templates`,
             newTemplateData1
         );
         expect(resp2).toMatchObject({ status: "success" });
@@ -242,14 +246,14 @@ function templateTests(api = { apiGET, apiPOST }) {
 
         // another one
         const resp3 = await apiPOST(
-            `/sessions/${session.id}/contract_templates`,
+            `/admin/sessions/${session.id}/contract_templates`,
             newTemplateData2
         );
         expect(resp3).toMatchObject({ status: "success" });
 
-        // fetchall templates us the templates we just created
+        // fetch all templates us the templates we just created
         const resp4 = await apiGET(
-            `/sessions/${session.id}/contract_templates`
+            `/admin/sessions/${session.id}/contract_templates`
         );
         expect(resp4.payload).toContainObject(newTemplateData1);
         expect(resp4.payload).toContainObject(newTemplateData2);
@@ -257,70 +261,70 @@ function templateTests(api = { apiGET, apiPOST }) {
         testTemplates = resp4.payload;
     });
 
-    it("update a template", async () => {
-        // create template had been tested
-        const templateToUpdate = testTemplates.filter(t => {
-            return (
-                t.template_file === newTemplateData2.template_file &&
-                t.template_name === newTemplateData2.template_name
-            );
-        });
-        expect(templateToUpdate.length).toBe(1);
-
-        // update new template
-        const updateData = {
-            ...templateToUpdate[0],
-            id: templateToUpdate[0].id,
-            contract_name: "Standard"
-        };
-        const resp1 = await apiPOST(
-            `/sessions/${session.id}/contract_templates`,
-            updateData
-        );
-        expect(resp1).toMatchObject({ status: "success" });
-        expect(resp1.payload).toMatchObject(updateData);
-
-        // make sure the template before update is gone
-        const resp2 = await apiGET(
-            `/sessions/${session.id}/contract_templates`
-        );
-        expect(resp2.payload).toContainObject(updateData);
-    });
-
-    // Backend API not checking empty props. Comment out the test case for now
-    it("throw error when `template_file` or `template_name` is empty", async () => {
-        const newTemplateData1 = {
-            template_file: "",
-            template_name: "Standard"
-        };
-        const newTemplateData2 = {
-            template_file: "this_is_a_test_template.html",
-            template_name: ""
-        };
-
-        // expected an error to crete new template with empty template_file
-        const resp1 = await apiPOST(
-            `/sessions/${session.id}/contract_templates`,
-            newTemplateData1
-        );
-        expect(resp1).toMatchObject({ status: "error" });
-        checkPropTypes(errorPropTypes, resp1);
-
-        // expected an error to crete new template with empty template_name
-        const resp2 = await apiPOST(
-            `/sessions/${session.id}/contract_templates`,
-            newTemplateData2
-        );
-        expect(resp2).toMatchObject({ status: "error" });
-        checkPropTypes(errorPropTypes, resp2);
-
-        // fetching the templates list and make sure it does not contain the above templates
-        const resp3 = await apiGET(
-            `/sessions/${session.id}/contract_templates`
-        );
-        expect(resp3.payload).not.toContainObject(newTemplateData1);
-        expect(resp3.payload).not.toContainObject(newTemplateData2);
-    });
+    //    it("update a template", async () => {
+    //        // create template had been tested
+    //        const templateToUpdate = testTemplates.filter(t => {
+    //            return (
+    //                t.template_file === newTemplateData2.template_file &&
+    //                t.template_name === newTemplateData2.template_name
+    //            );
+    //        });
+    //        expect(templateToUpdate.length).toBe(1);
+    //
+    //        // update new template
+    //        const updateData = {
+    //            ...templateToUpdate[0],
+    //            id: templateToUpdate[0].id,
+    //            contract_name: "Standard"
+    //        };
+    //        const resp1 = await apiPOST(
+    //            `/sessions/${session.id}/contract_templates`,
+    //            updateData
+    //        );
+    //        expect(resp1).toMatchObject({ status: "success" });
+    //        expect(resp1.payload).toMatchObject(updateData);
+    //
+    //        // make sure the template before update is gone
+    //        const resp2 = await apiGET(
+    //            `/sessions/${session.id}/contract_templates`
+    //        );
+    //        expect(resp2.payload).toContainObject(updateData);
+    //    });
+    //
+    //    // Backend API not checking empty props. Comment out the test case for now
+    //    it("throw error when `template_file` or `template_name` is empty", async () => {
+    //        const newTemplateData1 = {
+    //            template_file: "",
+    //            template_name: "Standard"
+    //        };
+    //        const newTemplateData2 = {
+    //            template_file: "this_is_a_test_template.html",
+    //            template_name: ""
+    //        };
+    //
+    //        // expected an error to crete new template with empty template_file
+    //        const resp1 = await apiPOST(
+    //            `/sessions/${session.id}/contract_templates`,
+    //            newTemplateData1
+    //        );
+    //        expect(resp1).toMatchObject({ status: "error" });
+    //        checkPropTypes(errorPropTypes, resp1);
+    //
+    //        // expected an error to crete new template with empty template_name
+    //        const resp2 = await apiPOST(
+    //            `/sessions/${session.id}/contract_templates`,
+    //            newTemplateData2
+    //        );
+    //        expect(resp2).toMatchObject({ status: "error" });
+    //        checkPropTypes(errorPropTypes, resp2);
+    //
+    //        // fetching the templates list and make sure it does not contain the above templates
+    //        const resp3 = await apiGET(
+    //            `/sessions/${session.id}/contract_templates`
+    //        );
+    //        expect(resp3.payload).not.toContainObject(newTemplateData1);
+    //        expect(resp3.payload).not.toContainObject(newTemplateData2);
+    //    });
 }
 
 function positionsTests(api = { apiGET, apiPOST }) {
@@ -589,11 +593,9 @@ describe("API tests", () => {
     describe("`/sessions` tests", () => {
         sessionsTests({ apiGET, apiPOST });
     });
-    // // XXX position_template was renamed contract_template. The backend needs to be fixed,
-    // // but it is being rewritten, so skip the test for now
-    // describe.skip("template tests", () => {
-    //     templateTests({ apiGET, apiPOST });
-    // });
+    describe.only("template tests", () => {
+        templateTests({ apiGET, apiPOST });
+    });
     // // XXX position_template was renamed contract_template. The backend needs to be fixed,
     // // but it is being rewritten, so skip the test for now
     // describe.skip("`/positions` tests", () => {

--- a/frontend/src/__tests__/utils.js
+++ b/frontend/src/__tests__/utils.js
@@ -55,6 +55,7 @@ export async function apiPOST(url, body = {}) {
     let resp = null;
     try {
         resp = await axios.post(url, body);
+        checkPropTypes(apiResponsePropTypes, resp.data);
     } catch (e) {
         // Modify the error to display some useful information
         throw new Error(
@@ -63,7 +64,6 @@ export async function apiPOST(url, body = {}) {
             )}\nfailed with error: ${e.message}`
         );
     }
-    checkPropTypes(apiResponsePropTypes, resp.data);
 
     // by this point, we have a valid response, so
     // just return the payload
@@ -119,7 +119,7 @@ export async function addContractTemplateToSession(api, session, num = 1) {
     let resp = {};
     for (let i = 0; i < num; i++) {
         resp = await api.apiPOST(
-            `/sessions/${session.id}/contract_templates`,
+            `/admin/sessions/${session.id}/contract_templates`,
             generateTemplateData(i)
         );
     }
@@ -144,7 +144,7 @@ export async function addSession(api, include = { contract_templates: true }) {
         rate1: 56.54
     };
     let resp = {};
-    resp = await api.apiPOST(`/sessions`, newSessionData);
+    resp = await api.apiPOST(`/admin/sessions`, newSessionData);
     const session = resp.payload;
     if (include.contract_templates) {
         addContractTemplateToSession(api, session);
@@ -161,7 +161,7 @@ export async function addSession(api, include = { contract_templates: true }) {
  * @returns
  */
 export async function deleteSession(api, session) {
-    const resp = await api.apiPOST(`/sessions/delete`, session);
+    const resp = await api.apiPOST(`/admin/sessions/delete`, session);
     return resp.payload;
 }
 
@@ -182,7 +182,7 @@ export async function addPosition(api, session) {
         end_date: "2018/09/09"
     };
     const resp = await api.apiPOST(
-        `/sessions/${session.id}/positions`,
+        `/admin/sessions/${session.id}/positions`,
         newPositionData
     );
     return resp.payload;
@@ -197,7 +197,7 @@ export async function addPosition(api, session) {
  * @returns
  */
 export async function deletePosition(api, position) {
-    const resp = await api.apiPOST(`/positions/delete`, position);
+    const resp = await api.apiPOST(`/admin/positions/delete`, position);
     return resp.payload;
 }
 
@@ -220,7 +220,16 @@ export function checkPropTypes(propTypes, data) {
             wasPropTypeErrors = true;
         }
     );
-    expect(wasPropTypeErrors).toBe(false);
+    if (wasPropTypeErrors) {
+        try {
+            throw new Error();
+        } catch (e) {
+            console.warn("Proptypes error call stack:", e.stack);
+        }
+        throw new Error(
+            `Object ${JSON.stringify(data)} failed proptypes check`
+        );
+    }
 }
 
 export const apiResponsePropTypes = apiPropTypes.apiResponse;


### PR DESCRIPTION
Unit tests were disabled when the new API backend was pulled. They are to be enabled one-by-one and the errors fixed accordingly.