### PR TITLE
Made `positions` render joined with data for ad and for matching

### DIFF
--- a/backend/app/controllers/api/v1/admin/assignments_controller.rb
+++ b/backend/app/controllers/api/v1/admin/assignments_controller.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class Api::V1::Admin::AssignmentsController < ApplicationController
+    # GET /contract_templates
+    def index
+        render_success Assignment.by_session(params[:session_id])
+    end
+
     # GET /assignments/:assignment_id
     def show
         @assignment = Assignment.find(params[:id])

--- a/backend/app/controllers/api/v1/admin/assignments_controller.rb
+++ b/backend/app/controllers/api/v1/admin/assignments_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::Admin::AssignmentsController < ApplicationController
-    # GET /contract_templates
+    # GET /sessions/:session_id/assignments
     def index
         render_success Assignment.by_session(params[:session_id])
     end

--- a/backend/app/controllers/api/v1/admin/instructors_controller.rb
+++ b/backend/app/controllers/api/v1/admin/instructors_controller.rb
@@ -8,9 +8,9 @@ class Api::V1::Admin::InstructorsController < ApplicationController
 
     # POST /instructors
     def create
-        @instructor = instructor.find_by(id: params[:instructor_id])
+        @instructor = Instructor.find_by(id: params[:instructor_id])
         update && return if @instructor
-        @instructor = instructor.new(instructor_params)
+        @instructor = Instructor.new(instructor_params)
         render_on_condition(object: @instructor,
                             condition: proc { @instructor.save! })
     end

--- a/backend/app/controllers/api/v1/admin/positions_controller.rb
+++ b/backend/app/controllers/api/v1/admin/positions_controller.rb
@@ -24,21 +24,16 @@ class Api::V1::Admin::PositionsController < ApplicationController
                 service = @position.as_position_service
                 service.update(params: position_params)
             end
-            render_success @position if @position
-            return
-        end
-
         # create a new position if one doesn't currently exist
-        start_transaction_and_rollback_on_exception do
-            service = PositionService.new(params: position_params.except(:id))
-            service.perform
-            @position = service.position
+        else
+            start_transaction_and_rollback_on_exception do
+                service = PositionService.new(params: position_params.except(:id))
+                service.perform
+                @position = service.position
+            end
         end
 
-        # if @position == nil at this point, there was an error which
-        # is being currently rendered. Therefore, we'd better not try to render
-        # a success.
-        render_success @position if @position
+        render_success @position
     end
 
     def find_position

--- a/backend/app/controllers/api/v1/admin/positions_controller.rb
+++ b/backend/app/controllers/api/v1/admin/positions_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::Admin::PositionsController < ApplicationController
 
     # POST /positions/delete
     def delete
-        render_success(object: @position, condition: proc { @position.destroy! })
+        render_on_condition(object: @position, condition: proc { @position.destroy! })
     end
 
     # This method may be manually called from other controllers. Because

--- a/backend/app/controllers/api/v1/admin/positions_controller.rb
+++ b/backend/app/controllers/api/v1/admin/positions_controller.rb
@@ -1,18 +1,39 @@
 # frozen_string_literal: true
 
 class Api::V1::Admin::PositionsController < ApplicationController
-    before_action :find_position
+    before_action :find_position, :store_params
 
     # POST /positions
-    def update
-        render_on_condition(object: @position, condition: proc {
-            @position.update!(position_update_params)
-        })
+    def create
+        render_success upsert(params: @params, position: @position)
     end
 
     # POST /positions/delete
     def delete
         render_success(object: @position, condition: proc { @position.destroy! })
+    end
+
+    # This method may be manually called from other controllers. Because
+    # of that, it doesn't render, instead leaving rendering up to the caller
+    def upsert(params:, position: nil)
+        @params = params
+        @position = position
+
+        # update the position if we have one
+        if @position
+            start_transaction_and_rollback_on_exception do
+                service = @position.as_position_service
+                service.update(params: position_params)
+                return @position
+            end
+        end
+
+        # create a new position if one doesn't currently exist
+        start_transaction_and_rollback_on_exception do
+            service = PositionService.new(params: position_params)
+            service.perform
+            @position = service.position
+        end
     end
 
     private
@@ -21,11 +42,16 @@ class Api::V1::Admin::PositionsController < ApplicationController
         @position = Position.find(params[:id])
     end
 
-    def position_update_params
-        params.permit(:id, :position_code, :position_title, :hours_per_assignment,
-                      :start_date, :end_date, :duties, :qualifications,
-                      :ad_hours_per_assignment, :ad_num_assignments, :ad_open_date,
-                      :ad_close_date, :desired_num_assignments, :current_enrollment,
-                      :current_waitlisted, :instructor_ids)
+    def store_params
+        @params = params
+    end
+
+    def position_params
+        @params.permit(:id, :position_code, :position_title, :hours_per_assignment,
+                       :start_date, :end_date, :session_id, :contract_template_id,
+                       :desired_num_assignments, :current_enrollment, :current_waitlisted,
+                       :duties, :qualifications, :ad_hours_per_assignment, :ad_num_assignments,
+                       :ad_open_date, :ad_close_date,
+                       instructor_ids: [])
     end
 end

--- a/backend/app/controllers/api/v1/admin/session_positions_controller.rb
+++ b/backend/app/controllers/api/v1/admin/session_positions_controller.rb
@@ -10,31 +10,19 @@ class Api::V1::Admin::SessionPositionsController < ApplicationController
 
     # POST /positions
     def create
-        @position = @session.positions.find_by(params[:id])
-        update && return if @position
-        @position = @session.positions.new(position_find_or_create_params)
-        render_on_condition(object: @position,
-                            condition: proc { @position.save! })
+        @position = @session.positions.find_by_id(params[:id])
+
+        # Call the PositionsConroller upsert method directly so we
+        # don't have to repeat logic. The `upsert` method is not the
+        # Rails upsert, it is custom created, so it is safe to call without
+        # properly "initializing" the conroller.
+        controller = self.class.module_parent::PositionsController.new
+        render_success controller.upsert(params: params, position: @position)
     end
 
     private
 
     def find_session
         @session = Session.find(params[:session_id])
-    end
-
-    def position_find_or_create_params
-        params.permit(:id, :position_code, :position_title, :hours_per_assignment,
-                      :start_date, :end_date, :duties, :qualifications,
-                      :ad_hours_per_assignment, :ad_num_assignments,
-                      :ad_open_date, :ad_close_date, :desired_num_assignments,
-                      :current_enrollment, :current_waitlisted, :instructor_ids)
-    end
-
-    def update
-        render_on_condition(object: @position,
-                            condition: proc {
-                                @position.update!(position_find_or_create_params)
-                            })
     end
 end

--- a/backend/app/controllers/api/v1/admin/session_positions_controller.rb
+++ b/backend/app/controllers/api/v1/admin/session_positions_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::V1::Admin::SessionPositionsController < ApplicationController
+class Api::V1::Admin::SessionPositionsController < Api::V1::Admin::PositionsController
     before_action :find_session
 
     # GET /positions
@@ -10,17 +10,15 @@ class Api::V1::Admin::SessionPositionsController < ApplicationController
 
     # POST /positions
     def create
-        @position = @session.positions.find_by_id(params[:id])
-
-        # Call the PositionsConroller upsert method directly so we
-        # don't have to repeat logic. The `upsert` method is not the
-        # Rails upsert, it is custom created, so it is safe to call without
-        # properly "initializing" the conroller.
-        controller = self.class.module_parent::PositionsController.new
-        render_success controller.upsert(params: params, position: @position)
+        upsert
     end
 
     private
+
+    def find_position
+        find_session
+        @position = @session.positions.find_by_id(params[:id])
+    end
 
     def find_session
         @session = Session.find(params[:session_id])

--- a/backend/app/controllers/concerns/response.rb
+++ b/backend/app/controllers/concerns/response.rb
@@ -3,11 +3,15 @@
 # responds with json and HTTP code status
 module Response
     def render_success(payload = {})
-        # active records have their own serializers, so use the
-        # serializer if we are an active record. Otherwise, pass the
-        # payload through.
-        payload = ActiveModelSerializers::SerializableResource.new(payload) if payload
-        render json: { status: 'success', message: '', payload: payload }
+        # If an error is rendering already, we don't want to try to render
+        # a success, so do a no-op instead
+        unless performed?
+            # active records have their own serializers, so use the
+            # serializer if we are an active record. Otherwise, pass the
+            # payload through.
+            payload = ActiveModelSerializers::SerializableResource.new(payload) if payload
+            render json: { status: 'success', message: '', payload: payload }
+        end
     end
 
     def render_error(message:, payload: {})

--- a/backend/app/controllers/concerns/response.rb
+++ b/backend/app/controllers/concerns/response.rb
@@ -6,11 +6,7 @@ module Response
         # active records have their own serializers, so use the
         # serializer if we are an active record. Otherwise, pass the
         # payload through.
-        payload = if payload.is_a?(ActiveRecord::Base)
-                      ActiveModelSerializers::SerializableResource.new(payload)
-                  else
-                      payload
-                  end
+        payload = ActiveModelSerializers::SerializableResource.new(payload) if payload
         render json: { status: 'success', message: '', payload: payload }
     end
 

--- a/backend/app/controllers/concerns/transaction_handler.rb
+++ b/backend/app/controllers/concerns/transaction_handler.rb
@@ -7,7 +7,15 @@ module TransactionHandler
         ActiveRecord::Base.transaction do
             yield
         rescue StandardError => e
-            render_error(message: e.message)
+            begin
+                render_error(message: e.message)
+            rescue NoMethodError
+                # if `start_transaction_and_rollback_on_exception` is executed
+                # outside of a controller context, `render_error` will itself fail.
+                # We aren't interested in its error. We want to bubble up the original
+                # error that started it all.
+                raise e
+            end
         end
     end
 end

--- a/backend/app/models/assignment.rb
+++ b/backend/app/models/assignment.rb
@@ -15,6 +15,11 @@ class Assignment < ApplicationRecord
     validates_uniqueness_of :applicant_id, scope: [:position_id]
 
     scope :by_position, ->(position_id) { where(position_id: position_id).order(:id) }
+    scope(:by_session, lambda do |session_id|
+        joins(:position)
+            .where('positions.session_id = ?', session_id)
+            .distinct.order(:id)
+    end)
 
     after_create :split_and_create_wage_chunks
 

--- a/backend/app/models/instructor.rb
+++ b/backend/app/models/instructor.rb
@@ -3,7 +3,7 @@
 class Instructor < ApplicationRecord
     has_and_belongs_to_many :positions
 
-    validates_presence_of :last_name, :first_name, :utorid, :email
+    validates_presence_of :last_name, :first_name, :utorid
     validates_uniqueness_of :utorid
 end
 

--- a/backend/app/models/position.rb
+++ b/backend/app/models/position.rb
@@ -6,14 +6,18 @@ class Position < ApplicationRecord
     has_many :assignments
     has_many :position_preferences
     has_many :applications, through: :position_preferences
-    has_one :position_data_for_ad
-    has_one :position_data_for_matching
+    has_one :position_data_for_ad, dependent: :destroy
+    has_one :position_data_for_matching, dependent: :destroy
     belongs_to :session
     belongs_to :contract_template
 
     validates :hours_per_assignment, numericality: { only_float: true }, allow_nil: true
     validates :position_code, presence: true, uniqueness: { scope: :session }
     validates :start_date, :end_date, presence: true
+
+    def as_position_service
+        PositionService.new(position: self)
+    end
 end
 
 # == Schema Information

--- a/backend/app/serializers/position_serializer.rb
+++ b/backend/app/serializers/position_serializer.rb
@@ -1,9 +1,21 @@
 # frozen_string_literal: true
 
 class PositionSerializer < ActiveModel::Serializer
-    attributes :id, :position_code, :position_title, :hours_per_assignment,
-               :start_date, :end_date, :duties, :qualifications,
-               :ad_hours_per_assignment, :ad_num_assignments, :ad_open_date,
-               :ad_close_date, :desired_num_assignments, :current_enrollment,
-               :current_waitlisted, :instructor_ids
+    def initialize(*args, **kwargs)
+        super(*args, **kwargs)
+        # We want to combine position's data with position_data_for_matching
+        # and position_data_for_ad. `PositionService` does exactly this.
+        @service = object.as_position_service
+    end
+
+    private
+
+    def attributes(*_args)
+        @service.values.slice(:id, :position_code,
+                              :start_date, :end_date,
+                              :qualifications, :duties,
+                              :ad_hours_per_assignment, :ad_num_assignments, :ad_open_date,
+                              :ad_close_date, :desired_num_assignments, :current_enrollment,
+                              :current_waitlisted, :instructor_ids)
+    end
 end

--- a/backend/app/services/position_service.rb
+++ b/backend/app/services/position_service.rb
@@ -14,6 +14,7 @@ class PositionService
     def perform
         @position = Position.new(position_params)
         @position.save!
+        @position.instructor_ids = instructor_id_params if instructor_id_params
         @position_data_for_ad = @position.create_position_data_for_ad(position_data_for_ad_params)
         @position_data_for_matching = @position.create_position_data_for_matching(position_data_for_matching_params)
         @position_data_for_matching.save!
@@ -23,6 +24,7 @@ class PositionService
     def update(params:)
         @params = params
         @position.update!(position_params)
+        @position.instructor_ids = instructor_ids if instructor_ids
         @position_data_for_ad.update!(position_data_for_ad_params)
         @position_data_for_matching.update!(position_data_for_matching_params)
     end
@@ -33,7 +35,8 @@ class PositionService
         @all_position_attrs = (@position_data_for_matching.as_json || {})
                               .merge(@position_data_for_ad.as_json || {})
                               .merge(@position.as_json)
-                              .merge(instructor_ids: []).symbolize_keys
+                              .merge(instructor_ids: @position.instructor_ids)
+                              .symbolize_keys
     end
 
     private
@@ -52,5 +55,9 @@ class PositionService
         @params.slice(:duties, :qualifications,
                       :ad_hours_per_assignment, :ad_num_assignments,
                       :ad_open_date, :ad_close_date)
+    end
+
+    def instructor_ids
+        @params[:instructor_ids]
     end
 end

--- a/backend/app/services/position_service.rb
+++ b/backend/app/services/position_service.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class PositionService
+    attr_reader :position
+
+    def initialize(params: nil, position: nil)
+        @params = params
+        @position = position
+        @position_data_for_matching = @position.position_data_for_matching if @position
+        @position_data_for_ad = @position.position_data_for_ad if @position
+        @all_position_attrs = {}
+    end
+
+    def perform
+        @position = Position.new(position_params)
+        @position.save!
+        @position_data_for_ad = @position.create_position_data_for_ad(position_data_for_ad_params)
+        @position_data_for_matching = @position.create_position_data_for_matching(position_data_for_matching_params)
+        @position_data_for_matching.save!
+        @position_data_for_ad.save!
+    end
+
+    def update(params:)
+        @params = params
+        @position.update!(position_params)
+        @position_data_for_ad.update!(position_data_for_ad_params)
+        @position_data_for_matching.update!(position_data_for_matching_params)
+    end
+
+    def values
+        # merge @position attrs last so the `id`
+        # field is the position id
+        @all_position_attrs = (@position_data_for_matching.as_json || {})
+                              .merge(@position_data_for_ad.as_json || {})
+                              .merge(@position.as_json)
+                              .merge(instructor_ids: []).symbolize_keys
+    end
+
+    private
+
+    def position_params
+        @params.slice(:id, :position_code, :position_title, :hours_per_assignment,
+                      :start_date, :end_date,
+                      :session_id, :contract_template_id)
+    end
+
+    def position_data_for_matching_params
+        @params.slice(:desired_num_assignments, :current_enrollment, :current_waitlisted)
+    end
+
+    def position_data_for_ad_params
+        @params.slice(:duties, :qualifications,
+                      :ad_hours_per_assignment, :ad_num_assignments,
+                      :ad_open_date, :ad_close_date)
+    end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -45,14 +45,14 @@ Rails.application.routes.draw do
                 end
 
                 # Instructors
-                resources :instructors, only: %i[create] do
+                resources :instructors, only: %i[index create] do
                     collection do
                         post :delete
                     end
                 end
 
                 # Positions
-                resources :positions, only: %i[index create] do
+                resources :positions, only: %i[create] do
                     collection do
                         post :delete
                     end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -45,7 +45,7 @@ Rails.application.routes.draw do
                 end
 
                 # Instructors
-                resources :instructors, only: %i[index create] do
+                resources :instructors, only: %i[create] do
                     collection do
                         post :delete
                     end

--- a/backend/db/migrate/20191108194831_create_positions.rb
+++ b/backend/db/migrate/20191108194831_create_positions.rb
@@ -5,8 +5,8 @@ class CreatePositions < ActiveRecord::Migration[6.0]
       t.string :position_code
       t.string :position_title
       t.float :hours_per_assignment
-      t.datetime :start_date, null: false
-      t.datetime :end_date, null: false
+      t.datetime :start_date
+      t.datetime :end_date
 
       t.timestamps
     end

--- a/backend/db/migrate/20191110204012_create_instructors.rb
+++ b/backend/db/migrate/20191110204012_create_instructors.rb
@@ -1,9 +1,9 @@
 class CreateInstructors < ActiveRecord::Migration[6.0]
   def change
     create_table :instructors do |t|
-      t.string :first_name, null: false
-      t.string :last_name, null: false
-      t.string :email, null: false
+      t.string :first_name
+      t.string :last_name
+      t.string :email
       t.string :utorid, null: false
 
       t.timestamps


### PR DESCRIPTION
The data stored in `position`, `position_data_for_matching` and `position_data_for_ad` should all be joined when rendered. This PR creates a new `PositionService` to help create and get all needed data associated with a position.

**TODO** This PR does not yet handle the `instructor_ids` field correctly.