### PR TITLE
refactor template tests for frontend

### DIFF
--- a/frontend/src/tests/api.test.js
+++ b/frontend/src/tests/api.test.js
@@ -25,144 +25,7 @@ import {
 import { mockAPI } from "../api/mockAPI";
 import { databaseSeeder } from "./setup";
 import { sessionsTests } from "./session-tests";
-
-function templateTests(api = { apiGET, apiPOST }) {
-    const { apiGET, apiPOST } = api;
-    let session = null,
-        testTemplates = null;
-
-    const newTemplateData1 = {
-        template_file: "this_is_a_test_template.html",
-        template_name: "OTO"
-    };
-    const newTemplateData2 = {
-        template_file: "this_is_a_test_template.html",
-        template_name: "Invigilate"
-    };
-    // set up a session to be available before tests run
-    beforeAll(async () => {
-        await apiPOST("/admin/debug/snapshot");
-        //await apiPOST("/admin/debug/clear_data");
-        // this session will be available for all tests
-        session = await addSession({ apiGET, apiPOST });
-    }, 15000);
-    // delete the session after the tests run
-    afterAll(async () => {
-        await apiPOST("/admin/debug/restore_snapshot");
-    });
-
-    it("fetch available templates", async () => {
-        const resp = await apiGET("/admin/available_contract_templates");
-        expect(resp).toMatchObject({ status: "success" });
-        checkPropTypes(
-            PropTypes.arrayOf(offerTemplateMinimalPropTypes),
-            resp.payload
-        );
-    });
-
-    it("add template to session", async () => {
-        // grab the contract_templates of the new session. They may have
-        // pre-populated.
-        const resp1 = await apiGET(
-            `/admin/sessions/${session.id}/contract_templates`
-        );
-        expect(resp1).toMatchObject({ status: "success" });
-        checkPropTypes(
-            PropTypes.arrayOf(offerTemplatePropTypes),
-            resp1.payload
-        );
-
-        // add the new offer template
-        const resp2 = await apiPOST(
-            `/admin/sessions/${session.id}/contract_templates`,
-            newTemplateData1
-        );
-        expect(resp2).toMatchObject({ status: "success" });
-        checkPropTypes(offerTemplatePropTypes, resp2.payload);
-        expect(resp2.payload).toMatchObject(newTemplateData1);
-
-        // another one
-        const resp3 = await apiPOST(
-            `/admin/sessions/${session.id}/contract_templates`,
-            newTemplateData2
-        );
-        expect(resp3).toMatchObject({ status: "success" });
-
-        // fetch all templates us the templates we just created
-        const resp4 = await apiGET(
-            `/admin/sessions/${session.id}/contract_templates`
-        );
-        expect(resp4.payload).toContainObject(newTemplateData1);
-        expect(resp4.payload).toContainObject(newTemplateData2);
-
-        testTemplates = resp4.payload;
-    });
-
-    //    it("update a template", async () => {
-    //        // create template had been tested
-    //        const templateToUpdate = testTemplates.filter(t => {
-    //            return (
-    //                t.template_file === newTemplateData2.template_file &&
-    //                t.template_name === newTemplateData2.template_name
-    //            );
-    //        });
-    //        expect(templateToUpdate.length).toBe(1);
-    //
-    //        // update new template
-    //        const updateData = {
-    //            ...templateToUpdate[0],
-    //            id: templateToUpdate[0].id,
-    //            contract_name: "Standard"
-    //        };
-    //        const resp1 = await apiPOST(
-    //            `/sessions/${session.id}/contract_templates`,
-    //            updateData
-    //        );
-    //        expect(resp1).toMatchObject({ status: "success" });
-    //        expect(resp1.payload).toMatchObject(updateData);
-    //
-    //        // make sure the template before update is gone
-    //        const resp2 = await apiGET(
-    //            `/sessions/${session.id}/contract_templates`
-    //        );
-    //        expect(resp2.payload).toContainObject(updateData);
-    //    });
-    //
-    //    // Backend API not checking empty props. Comment out the test case for now
-    //    it("throw error when `template_file` or `template_name` is empty", async () => {
-    //        const newTemplateData1 = {
-    //            template_file: "",
-    //            template_name: "Standard"
-    //        };
-    //        const newTemplateData2 = {
-    //            template_file: "this_is_a_test_template.html",
-    //            template_name: ""
-    //        };
-    //
-    //        // expected an error to crete new template with empty template_file
-    //        const resp1 = await apiPOST(
-    //            `/sessions/${session.id}/contract_templates`,
-    //            newTemplateData1
-    //        );
-    //        expect(resp1).toMatchObject({ status: "error" });
-    //        checkPropTypes(errorPropTypes, resp1);
-    //
-    //        // expected an error to crete new template with empty template_name
-    //        const resp2 = await apiPOST(
-    //            `/sessions/${session.id}/contract_templates`,
-    //            newTemplateData2
-    //        );
-    //        expect(resp2).toMatchObject({ status: "error" });
-    //        checkPropTypes(errorPropTypes, resp2);
-    //
-    //        // fetching the templates list and make sure it does not contain the above templates
-    //        const resp3 = await apiGET(
-    //            `/sessions/${session.id}/contract_templates`
-    //        );
-    //        expect(resp3.payload).not.toContainObject(newTemplateData1);
-    //        expect(resp3.payload).not.toContainObject(newTemplateData2);
-    //    });
-}
+import { templatesTests } from "./template-tests";
 
 function positionsTests(api = { apiGET, apiPOST }) {
     const { apiGET, apiPOST } = api;
@@ -422,12 +285,10 @@ describe("API tests", () => {
     describe("`/sessions` tests", () => {
         sessionsTests(api);
     });
-    //     describe("`/sessions` tests", () => {
-    //         sessionsTests({ apiGET, apiPOST });
-    //     });
-    //     describe.only("template tests", () => {
-    //         templateTests({ apiGET, apiPOST });
-    //     });
+
+    describe("template tests", () => {
+        templatesTests(api);
+    });
     //     // // XXX position_template was renamed contract_template. The backend needs to be fixed,
     //     // // but it is being rewritten, so skip the test for now
     //     // describe.skip("`/positions` tests", () => {
@@ -464,9 +325,9 @@ describe("Mock API tests", () => {
     describe("`/sessions` tests", () => {
         sessionsTests(mockAPI);
     });
-    // describe("template tests", () => {
-    //     templateTests(mockAPI);
-    // });
+    describe("template tests", () => {
+        templatesTests(mockAPI);
+    });
     // describe("`/positions` tests", () => {
     //     positionsTests(mockAPI);
     // });

--- a/frontend/src/tests/api.test.js
+++ b/frontend/src/tests/api.test.js
@@ -286,9 +286,9 @@ describe("API tests", () => {
         sessionsTests(api);
     });
 
-    describe("template tests", () => {
-        templatesTests(api);
-    });
+    // describe("template tests", () => {
+    //     templatesTests(api);
+    // });
     //     // // XXX position_template was renamed contract_template. The backend needs to be fixed,
     //     // // but it is being rewritten, so skip the test for now
     //     // describe.skip("`/positions` tests", () => {

--- a/frontend/src/tests/template-tests.js
+++ b/frontend/src/tests/template-tests.js
@@ -1,0 +1,170 @@
+import PropTypes from "prop-types";
+import {
+    apiGET,
+    apiPOST,
+    addSession,
+    deleteSession,
+    addPosition,
+    deletePosition,
+    checkPropTypes,
+    offerTemplateMinimalPropTypes,
+    offerTemplatePropTypes,
+    positionPropTypes,
+    instructorPropTypes,
+    errorPropTypes,
+    expect,
+    describe,
+    it,
+    beforeAll,
+    afterAll
+} from "./utils";
+import { databaseSeeder } from "./setup";
+/**
+ * Tests for the API. These are encapsulated in a function so that
+ * different `apiGET` and `apiPOST` functions can be passed in. For example,
+ * they may be functions that make actual requests via http or they may
+ * be from the mock API.
+ *
+ * @param {object} api
+ * @param {Function} api.apiGET A function that when passed a route will return the get response
+ * @param {Function} api.apiPOST A function that when passed a route and data, will return the post response
+ */
+export function templatesTests(api) {
+    const { apiGET, apiPOST } = api;
+    let session = null,
+        testTemplates = null;
+
+    const newTemplateData1 = {
+        template_file: "this_is_a_test_template.html",
+        template_name: "OTO"
+    };
+    const newTemplateData2 = {
+        template_file: "this_is_a_test_template.html",
+        template_name: "Invigilate"
+    };
+    // set up a session to be available before tests run
+
+    beforeAll(async () => {
+        await apiPOST("/debug/restore_snapshot");
+        session = databaseSeeder.seededData.session;
+    }, 30000);
+
+    it("fetch available templates", async () => {
+        const resp = await apiGET("/admin/available_contract_templates");
+
+        expect(resp).toMatchObject({ status: "success" });
+        checkPropTypes(
+            PropTypes.arrayOf(offerTemplateMinimalPropTypes),
+            resp.payload
+        );
+    });
+
+    it("add template to session", async () => {
+        // grab the contract_templates of the new session. They may have
+        // pre-populated.
+        const resp1 = await apiGET(
+            `/admin/sessions/${session.id}/contract_templates`
+        );
+        expect(resp1).toMatchObject({ status: "success" });
+
+        checkPropTypes(
+            PropTypes.arrayOf(offerTemplatePropTypes),
+            resp1.payload
+        );
+
+        // add the new offer template
+        const resp2 = await apiPOST(
+            `/admin/sessions/${session.id}/contract_templates`,
+            newTemplateData1
+        );
+
+        expect(resp2).toMatchObject({ status: "success" });
+        checkPropTypes(offerTemplatePropTypes, resp2.payload);
+        expect(resp2.payload).toMatchObject(newTemplateData1);
+
+        // another one
+        const resp3 = await apiPOST(
+            `/admin/sessions/${session.id}/contract_templates`,
+            newTemplateData2
+        );
+        expect(resp3).toMatchObject({ status: "success" });
+
+        // fetch all templates us the templates we just created
+        const resp4 = await apiGET(
+            `/admin/sessions/${session.id}/contract_templates`
+        );
+
+        expect(resp4.payload).toContainObject(newTemplateData1);
+        expect(resp4.payload).toContainObject(newTemplateData2);
+
+        testTemplates = resp4.payload;
+    });
+
+    it("update a template", async () => {
+        // create template had been tested
+        const templateToUpdate = testTemplates.filter(t => {
+            return (
+                t.template_file === newTemplateData2.template_file &&
+                t.template_name === newTemplateData2.template_name
+            );
+        });
+
+        expect(templateToUpdate.length).toBe(1);
+
+        // update new template
+        const updateData = {
+            ...templateToUpdate[0],
+            id: templateToUpdate[0].id,
+            contract_name: "Standard"
+        };
+        const resp1 = await apiPOST(
+            `/sessions/${session.id}/contract_templates`,
+            updateData
+        );
+
+        expect(resp1).toMatchObject({ status: "success" });
+        expect(resp1.payload).toMatchObject(updateData);
+
+        // make sure the template before update is gone
+        const resp2 = await apiGET(
+            `/sessions/${session.id}/contract_templates`
+        );
+
+        expect(resp2.payload).toContainObject(updateData);
+    });
+
+    // Backend API not checking empty props. Comment out the test case for now
+    it("throw error when `template_file` or `template_name` is empty", async () => {
+        const newTemplateData1 = {
+            template_file: "",
+            template_name: "Standard"
+        };
+        const newTemplateData2 = {
+            template_file: "this_is_a_test_template.html",
+            template_name: ""
+        };
+
+        // expected an error to crete new template with empty template_file
+        const resp1 = await apiPOST(
+            `/sessions/${session.id}/contract_templates`,
+            newTemplateData1
+        );
+        expect(resp1).toMatchObject({ status: "error" });
+        checkPropTypes(errorPropTypes, resp1);
+
+        // expected an error to crete new template with empty template_name
+        const resp2 = await apiPOST(
+            `/sessions/${session.id}/contract_templates`,
+            newTemplateData2
+        );
+        expect(resp2).toMatchObject({ status: "error" });
+        checkPropTypes(errorPropTypes, resp2);
+
+        // fetching the templates list and make sure it does not contain the above templates
+        const resp3 = await apiGET(
+            `/sessions/${session.id}/contract_templates`
+        );
+        expect(resp3.payload).not.toContainObject(newTemplateData1);
+        expect(resp3.payload).not.toContainObject(newTemplateData2);
+    });
+}

--- a/frontend/src/tests/template-tests.js
+++ b/frontend/src/tests/template-tests.js
@@ -1,22 +1,12 @@
 import PropTypes from "prop-types";
 import {
-    apiGET,
-    apiPOST,
-    addSession,
-    deleteSession,
-    addPosition,
-    deletePosition,
     checkPropTypes,
     offerTemplateMinimalPropTypes,
     offerTemplatePropTypes,
-    positionPropTypes,
-    instructorPropTypes,
     errorPropTypes,
     expect,
-    describe,
     it,
-    beforeAll,
-    afterAll
+    beforeAll
 } from "./utils";
 import { databaseSeeder } from "./setup";
 /**


### PR DESCRIPTION
- move the template test from api.test.js to a separate file.
- refactor some of the tests