### PR TITLE
Removed foreign key requirements & other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,16 @@ To view the STDOUT from a docker container of a running server, you can invoke
 
 To stop everything, use `docker-compose down`.
 
+To run the ruby console hooked into the current rails session, run
+
+`docker-compose exec backend rails c`
+
+To manually inspect the binary snapshots in  the `pg_dump` folder, run
+
+`pg_restore  2020_04_26__01_12_39_tapp_development.psql`
+
+which will display the output to the command line (it won't actually insert into a database.)
+
 ### Navigating into the containers from the command line
 
 Currently, we define three services under docker-compose: frontend, api, and

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,13 +1,15 @@
 FROM madnight/docker-alpine-wkhtmltopdf:latest as wkhtmltopdf_image
 FROM ruby:2.6.5-alpine3.10
 
-# Add tzdata because the Gemfile doesn't successfully add the dependency via geminstall.
+# Add `tzdata` because the Gemfile doesn't successfully add the dependency via geminstall.
+# Add `less` because the ruby console attempts to call `less` and errors when it doesn't exist
 RUN apk update && apk add build-base \
   nodejs \
   postgresql-dev \
   tzdata \
   graphviz \
-  postgresql-client
+  postgresql-client \
+  less
 
 RUN apk add --update --no-cache \
   libgcc libstdc++ libx11 glib libxrender libxext libintl \

--- a/backend/app/models/position.rb
+++ b/backend/app/models/position.rb
@@ -3,8 +3,8 @@
 class Position < ApplicationRecord
     has_and_belongs_to_many :instructors
     has_and_belongs_to_many :reporting_tags
-    has_many :assignments
-    has_many :position_preferences
+    has_many :assignments, dependent: :destroy
+    has_many :position_preferences, dependent: :destroy
     has_many :applications, through: :position_preferences
     has_one :position_data_for_ad, dependent: :destroy
     has_one :position_data_for_matching, dependent: :destroy
@@ -14,6 +14,22 @@ class Position < ApplicationRecord
     validates :hours_per_assignment,
               numericality: { only_float: true }, allow_nil: true
     validates :position_code, presence: true, uniqueness: { scope: :session }
+
+    def start_date
+        # If we have a non-null date, return that. Otherwise
+        # we return the date from the session
+        return self[:start_date] if self[:start_date]
+
+        session.start_date
+    end
+
+    def end_date
+        # If we have a non-null date, return that. Otherwise
+        # we return the date from the session
+        return self[:end_date] if self[:end_date]
+
+        session.end_date
+    end
 end
 
 # == Schema Information

--- a/backend/app/models/reporting_tag.rb
+++ b/backend/app/models/reporting_tag.rb
@@ -12,8 +12,8 @@ end
 # Table name: reporting_tags
 #
 #  id            :integer          not null, primary key
-#  position_id   :integer          not null
-#  wage_chunk_id :integer          not null
+#  position_id   :integer
+#  wage_chunk_id :integer
 #  name          :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null

--- a/backend/app/models/session.rb
+++ b/backend/app/models/session.rb
@@ -2,9 +2,11 @@
 
 # A class representing a school term. For example, "fall 2018".
 class Session < ApplicationRecord
-    has_many :applications
-    has_many :contract_templates
-    has_many :positions
+    has_many :applications, dependent: :destroy
+    # positions must be listed first. Since they also may contain references to
+    # `constract_templates`, there is a potential foreign key issue when destroying them
+    has_many :positions, dependent: :destroy
+    has_many :contract_templates, dependent: :destroy
 
     validates :rate1, numericality: { only_float: true }, allow_nil: true
     validates :rate2, numericality: { only_float: true }, allow_nil: true

--- a/backend/db/migrate/20191110202155_create_reporting_tags.rb
+++ b/backend/db/migrate/20191110202155_create_reporting_tags.rb
@@ -1,8 +1,8 @@
 class CreateReportingTags < ActiveRecord::Migration[6.0]
     def change
         create_table :reporting_tags do |t|
-            t.references :position, null: false, foreign_key: true
-            t.references :wage_chunk, null: false, foreign_key: true
+            t.references :position, foreign_key: true
+            t.references :wage_chunk, foreign_key: true
             t.string :name
 
             t.timestamps

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,259 +10,236 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_29_181519) do
-    # These are extensions that must be enabled in order to support this database
-    enable_extension 'plpgsql'
+ActiveRecord::Schema.define(version: 2019_11_15_081814) do
 
-    create_table 'active_users', force: :cascade do |t|
-        t.text 'credentials'
-        t.datetime 'created_at', precision: 6, null: false
-        t.datetime 'updated_at', precision: 6, null: false
-    end
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
 
-    create_table 'applicant_data_for_matchings', force: :cascade do |t|
-        t.bigint 'applicant_id', null: false
-        t.string 'program'
-        t.string 'department'
-        t.text 'previous_uoft_experience'
-        t.integer 'yip'
-        t.string 'annotation'
-        t.datetime 'created_at', precision: 6, null: false
-        t.datetime 'updated_at', precision: 6, null: false
-        t.index %w[applicant_id],
-                name: 'index_applicant_data_for_matchings_on_applicant_id'
-    end
+  create_table "applicant_data_for_matchings", force: :cascade do |t|
+    t.bigint "applicant_id", null: false
+    t.string "program"
+    t.string "department"
+    t.text "previous_uoft_experience"
+    t.integer "yip"
+    t.string "annotation"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["applicant_id"], name: "index_applicant_data_for_matchings_on_applicant_id"
+  end
 
-    create_table 'applicants', force: :cascade do |t|
-        t.string 'utorid', null: false
-        t.string 'student_number'
-        t.string 'first_name'
-        t.string 'last_name'
-        t.string 'email'
-        t.string 'phone'
-        t.datetime 'created_at', precision: 6, null: false
-        t.datetime 'updated_at', precision: 6, null: false
-        t.index %w[utorid], name: 'index_applicants_on_utorid', unique: true
-    end
+  create_table "applicants", force: :cascade do |t|
+    t.string "utorid", null: false
+    t.string "student_number"
+    t.string "first_name"
+    t.string "last_name"
+    t.string "email"
+    t.string "phone"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["utorid"], name: "index_applicants_on_utorid", unique: true
+  end
 
-    create_table 'applications', force: :cascade do |t|
-        t.bigint 'session_id', null: false
-        t.bigint 'applicant_id', null: false
-        t.text 'comments'
-        t.datetime 'created_at', precision: 6, null: false
-        t.datetime 'updated_at', precision: 6, null: false
-        t.index %w[applicant_id], name: 'index_applications_on_applicant_id'
-        t.index %w[session_id], name: 'index_applications_on_session_id'
-    end
+  create_table "applications", force: :cascade do |t|
+    t.bigint "session_id", null: false
+    t.bigint "applicant_id", null: false
+    t.text "comments"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["applicant_id"], name: "index_applications_on_applicant_id"
+    t.index ["session_id"], name: "index_applications_on_session_id"
+  end
 
-    create_table 'assignments', force: :cascade do |t|
-        t.bigint 'position_id', null: false
-        t.bigint 'applicant_id', null: false
-        t.datetime 'start_date'
-        t.datetime 'end_date'
-        t.text 'note'
-        t.string 'offer_override_pdf'
-        t.integer 'active_offer_status', default: 0, null: false
-        t.datetime 'created_at', precision: 6, null: false
-        t.datetime 'updated_at', precision: 6, null: false
-        t.bigint 'active_offer_id'
-        t.index %w[active_offer_id],
-                name: 'index_assignments_on_active_offer_id'
-        t.index %w[applicant_id], name: 'index_assignments_on_applicant_id'
-        t.index %w[position_id applicant_id],
-                name: 'index_assignments_on_position_id_and_applicant_id',
-                unique: true
-        t.index %w[position_id], name: 'index_assignments_on_position_id'
-    end
+  create_table "assignments", force: :cascade do |t|
+    t.bigint "position_id", null: false
+    t.bigint "applicant_id", null: false
+    t.datetime "start_date"
+    t.datetime "end_date"
+    t.text "note"
+    t.string "offer_override_pdf"
+    t.integer "active_offer_status", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "active_offer_id"
+    t.index ["active_offer_id"], name: "index_assignments_on_active_offer_id"
+    t.index ["applicant_id"], name: "index_assignments_on_applicant_id"
+    t.index ["position_id", "applicant_id"], name: "index_assignments_on_position_id_and_applicant_id", unique: true
+    t.index ["position_id"], name: "index_assignments_on_position_id"
+  end
 
-    create_table 'contract_templates', force: :cascade do |t|
-        t.bigint 'session_id', null: false
-        t.string 'template_name'
-        t.string 'template_file'
-        t.datetime 'created_at', precision: 6, null: false
-        t.datetime 'updated_at', precision: 6, null: false
-        t.index %w[session_id], name: 'index_contract_templates_on_session_id'
-    end
+  create_table "contract_templates", force: :cascade do |t|
+    t.bigint "session_id", null: false
+    t.string "template_name"
+    t.string "template_file"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["session_id"], name: "index_contract_templates_on_session_id"
+  end
 
-    create_table 'instructors', force: :cascade do |t|
-        t.string 'first_name'
-        t.string 'last_name'
-        t.string 'email'
-        t.string 'utorid', null: false
-        t.datetime 'created_at', precision: 6, null: false
-        t.datetime 'updated_at', precision: 6, null: false
-        t.index %w[utorid], name: 'index_instructors_on_utorid', unique: true
-    end
+  create_table "instructors", force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+    t.string "email"
+    t.string "utorid", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["utorid"], name: "index_instructors_on_utorid", unique: true
+  end
 
-    create_table 'instructors_positions', force: :cascade do |t|
-        t.bigint 'instructor_id'
-        t.bigint 'position_id'
-        t.index %w[instructor_id],
-                name: 'index_instructors_positions_on_instructor_id'
-        t.index %w[position_id],
-                name: 'index_instructors_positions_on_position_id'
-    end
+  create_table "instructors_positions", force: :cascade do |t|
+    t.bigint "instructor_id"
+    t.bigint "position_id"
+    t.index ["instructor_id"], name: "index_instructors_positions_on_instructor_id"
+    t.index ["position_id"], name: "index_instructors_positions_on_position_id"
+  end
 
-    create_table 'offers', force: :cascade do |t|
-        t.bigint 'assignment_id', null: false
-        t.string 'offer_template'
-        t.string 'offer_override_pdf'
-        t.string 'first_name'
-        t.string 'last_name'
-        t.string 'email'
-        t.string 'position_code'
-        t.string 'position_title'
-        t.datetime 'position_start_date'
-        t.datetime 'position_end_date'
-        t.boolean 'first_time_ta'
-        t.string 'instructor_contact_desc'
-        t.string 'pay_period_desc'
-        t.integer 'installments'
-        t.string 'ta_coordinator_name'
-        t.string 'ta_coordinator_email'
-        t.datetime 'emailed_date'
-        t.string 'signature'
-        t.datetime 'accepted_date'
-        t.datetime 'rejected_date'
-        t.datetime 'withdrawn_date'
-        t.integer 'nag_count', default: 0
-        t.string 'url_token'
-        t.datetime 'created_at', precision: 6, null: false
-        t.datetime 'updated_at', precision: 6, null: false
-        t.integer 'status', default: 0, null: false
-        t.index %w[assignment_id], name: 'index_offers_on_assignment_id'
-        t.index %w[url_token], name: 'index_offers_on_url_token'
-    end
+  create_table "offers", force: :cascade do |t|
+    t.bigint "assignment_id", null: false
+    t.string "offer_template"
+    t.string "offer_override_pdf"
+    t.string "first_name"
+    t.string "last_name"
+    t.string "email"
+    t.string "position_code"
+    t.string "position_title"
+    t.datetime "position_start_date"
+    t.datetime "position_end_date"
+    t.boolean "first_time_ta"
+    t.string "instructor_contact_desc"
+    t.string "pay_period_desc"
+    t.integer "installments"
+    t.string "ta_coordinator_name"
+    t.string "ta_coordinator_email"
+    t.datetime "emailed_date"
+    t.string "signature"
+    t.datetime "accepted_date"
+    t.datetime "rejected_date"
+    t.datetime "withdrawn_date"
+    t.integer "nag_count", default: 0
+    t.string "url_token"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "status", default: 0, null: false
+    t.index ["assignment_id"], name: "index_offers_on_assignment_id"
+    t.index ["url_token"], name: "index_offers_on_url_token"
+  end
 
-    create_table 'position_data_for_ads', force: :cascade do |t|
-        t.bigint 'position_id', null: false
-        t.text 'duties'
-        t.text 'qualifications'
-        t.float 'ad_hours_per_assignment'
-        t.integer 'ad_num_assignments'
-        t.datetime 'ad_open_date'
-        t.datetime 'ad_close_date'
-        t.datetime 'created_at', precision: 6, null: false
-        t.datetime 'updated_at', precision: 6, null: false
-        t.index %w[position_id],
-                name: 'index_position_data_for_ads_on_position_id'
-    end
+  create_table "position_data_for_ads", force: :cascade do |t|
+    t.bigint "position_id", null: false
+    t.text "duties"
+    t.text "qualifications"
+    t.float "ad_hours_per_assignment"
+    t.integer "ad_num_assignments"
+    t.datetime "ad_open_date"
+    t.datetime "ad_close_date"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["position_id"], name: "index_position_data_for_ads_on_position_id"
+  end
 
-    create_table 'position_data_for_matchings', force: :cascade do |t|
-        t.bigint 'position_id', null: false
-        t.integer 'desired_num_assignments'
-        t.integer 'current_enrollment'
-        t.integer 'current_waitlisted'
-        t.datetime 'created_at', precision: 6, null: false
-        t.datetime 'updated_at', precision: 6, null: false
-        t.index %w[position_id],
-                name: 'index_position_data_for_matchings_on_position_id'
-    end
+  create_table "position_data_for_matchings", force: :cascade do |t|
+    t.bigint "position_id", null: false
+    t.integer "desired_num_assignments"
+    t.integer "current_enrollment"
+    t.integer "current_waitlisted"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["position_id"], name: "index_position_data_for_matchings_on_position_id"
+  end
 
-    create_table 'position_preferences', force: :cascade do |t|
-        t.bigint 'position_id', null: false
-        t.bigint 'application_id', null: false
-        t.integer 'preference_level'
-        t.datetime 'created_at', precision: 6, null: false
-        t.datetime 'updated_at', precision: 6, null: false
-        t.index %w[application_id],
-                name: 'index_position_preferences_on_application_id'
-        t.index %w[position_id application_id],
-                name:
-                    'index_position_preferences_on_position_id_and_application_id',
-                unique: true
-        t.index %w[position_id],
-                name: 'index_position_preferences_on_position_id'
-    end
+  create_table "position_preferences", force: :cascade do |t|
+    t.bigint "position_id", null: false
+    t.bigint "application_id", null: false
+    t.integer "preference_level"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["application_id"], name: "index_position_preferences_on_application_id"
+    t.index ["position_id", "application_id"], name: "index_position_preferences_on_position_id_and_application_id", unique: true
+    t.index ["position_id"], name: "index_position_preferences_on_position_id"
+  end
 
-    create_table 'positions', force: :cascade do |t|
-        t.bigint 'session_id', null: false
-        t.string 'position_code'
-        t.string 'position_title'
-        t.float 'hours_per_assignment'
-        t.datetime 'start_date'
-        t.datetime 'end_date'
-        t.datetime 'created_at', precision: 6, null: false
-        t.datetime 'updated_at', precision: 6, null: false
-        t.bigint 'contract_template_id', null: false
-        t.index %w[contract_template_id],
-                name: 'index_positions_on_contract_template_id'
-        t.index %w[session_id], name: 'index_positions_on_session_id'
-    end
+  create_table "positions", force: :cascade do |t|
+    t.bigint "session_id", null: false
+    t.string "position_code"
+    t.string "position_title"
+    t.float "hours_per_assignment"
+    t.datetime "start_date"
+    t.datetime "end_date"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "contract_template_id", null: false
+    t.index ["contract_template_id"], name: "index_positions_on_contract_template_id"
+    t.index ["session_id"], name: "index_positions_on_session_id"
+  end
 
-    create_table 'positions_reporting_tags', force: :cascade do |t|
-        t.bigint 'reporting_tag_id'
-        t.bigint 'position_id'
-        t.index %w[position_id],
-                name: 'index_positions_reporting_tags_on_position_id'
-        t.index %w[reporting_tag_id],
-                name: 'index_positions_reporting_tags_on_reporting_tag_id'
-    end
+  create_table "positions_reporting_tags", force: :cascade do |t|
+    t.bigint "reporting_tag_id"
+    t.bigint "position_id"
+    t.index ["position_id"], name: "index_positions_reporting_tags_on_position_id"
+    t.index ["reporting_tag_id"], name: "index_positions_reporting_tags_on_reporting_tag_id"
+  end
 
-    create_table 'reporting_tags', force: :cascade do |t|
-        t.bigint 'position_id', null: false
-        t.bigint 'wage_chunk_id', null: false
-        t.string 'name'
-        t.datetime 'created_at', precision: 6, null: false
-        t.datetime 'updated_at', precision: 6, null: false
-        t.index %w[position_id], name: 'index_reporting_tags_on_position_id'
-        t.index %w[wage_chunk_id], name: 'index_reporting_tags_on_wage_chunk_id'
-    end
+  create_table "reporting_tags", force: :cascade do |t|
+    t.bigint "position_id"
+    t.bigint "wage_chunk_id"
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["position_id"], name: "index_reporting_tags_on_position_id"
+    t.index ["wage_chunk_id"], name: "index_reporting_tags_on_wage_chunk_id"
+  end
 
-    create_table 'reporting_tags_wage_chunks', force: :cascade do |t|
-        t.bigint 'reporting_tag_id'
-        t.bigint 'wage_chunk_id'
-        t.index %w[reporting_tag_id],
-                name: 'index_reporting_tags_wage_chunks_on_reporting_tag_id'
-        t.index %w[wage_chunk_id],
-                name: 'index_reporting_tags_wage_chunks_on_wage_chunk_id'
-    end
+  create_table "reporting_tags_wage_chunks", force: :cascade do |t|
+    t.bigint "reporting_tag_id"
+    t.bigint "wage_chunk_id"
+    t.index ["reporting_tag_id"], name: "index_reporting_tags_wage_chunks_on_reporting_tag_id"
+    t.index ["wage_chunk_id"], name: "index_reporting_tags_wage_chunks_on_wage_chunk_id"
+  end
 
-    create_table 'sessions', force: :cascade do |t|
-        t.datetime 'start_date'
-        t.datetime 'end_date'
-        t.string 'name'
-        t.float 'rate1'
-        t.float 'rate2'
-        t.datetime 'created_at', precision: 6, null: false
-        t.datetime 'updated_at', precision: 6, null: false
-    end
+  create_table "sessions", force: :cascade do |t|
+    t.datetime "start_date"
+    t.datetime "end_date"
+    t.string "name"
+    t.float "rate1"
+    t.float "rate2"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
-    create_table 'users', force: :cascade do |t|
-        t.string 'utorid'
-        t.integer 'roles_mask'
-        t.datetime 'last_seen'
-        t.datetime 'created_at', precision: 6, null: false
-        t.datetime 'updated_at', precision: 6, null: false
-        t.index %w[utorid], name: 'index_users_on_utorid', unique: true
-    end
+  create_table "users", force: :cascade do |t|
+    t.string "utorid"
+    t.integer "roles_mask"
+    t.datetime "last_seen"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["utorid"], name: "index_users_on_utorid", unique: true
+  end
 
-    create_table 'wage_chunks', force: :cascade do |t|
-        t.bigint 'assignment_id', null: false
-        t.float 'hours'
-        t.float 'rate'
-        t.datetime 'start_date'
-        t.datetime 'end_date'
-        t.datetime 'created_at', precision: 6, null: false
-        t.datetime 'updated_at', precision: 6, null: false
-        t.index %w[assignment_id], name: 'index_wage_chunks_on_assignment_id'
-    end
+  create_table "wage_chunks", force: :cascade do |t|
+    t.bigint "assignment_id", null: false
+    t.float "hours"
+    t.float "rate"
+    t.datetime "start_date"
+    t.datetime "end_date"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["assignment_id"], name: "index_wage_chunks_on_assignment_id"
+  end
 
-    add_foreign_key 'applicant_data_for_matchings', 'applicants'
-    add_foreign_key 'applications', 'applicants'
-    add_foreign_key 'applications', 'sessions'
-    add_foreign_key 'assignments', 'applicants'
-    add_foreign_key 'assignments', 'offers', column: 'active_offer_id'
-    add_foreign_key 'assignments', 'positions'
-    add_foreign_key 'contract_templates', 'sessions'
-    add_foreign_key 'offers', 'assignments'
-    add_foreign_key 'position_data_for_ads', 'positions'
-    add_foreign_key 'position_data_for_matchings', 'positions'
-    add_foreign_key 'position_preferences', 'applications'
-    add_foreign_key 'position_preferences', 'positions'
-    add_foreign_key 'positions', 'contract_templates'
-    add_foreign_key 'positions', 'sessions'
-    add_foreign_key 'reporting_tags', 'positions'
-    add_foreign_key 'reporting_tags', 'wage_chunks'
-    add_foreign_key 'wage_chunks', 'assignments', on_delete: :cascade
+  add_foreign_key "applicant_data_for_matchings", "applicants"
+  add_foreign_key "applications", "applicants"
+  add_foreign_key "applications", "sessions"
+  add_foreign_key "assignments", "applicants"
+  add_foreign_key "assignments", "offers", column: "active_offer_id"
+  add_foreign_key "assignments", "positions"
+  add_foreign_key "contract_templates", "sessions"
+  add_foreign_key "offers", "assignments"
+  add_foreign_key "position_data_for_ads", "positions"
+  add_foreign_key "position_data_for_matchings", "positions"
+  add_foreign_key "position_preferences", "applications"
+  add_foreign_key "position_preferences", "positions"
+  add_foreign_key "positions", "contract_templates"
+  add_foreign_key "positions", "sessions"
+  add_foreign_key "reporting_tags", "positions"
+  add_foreign_key "reporting_tags", "wage_chunks"
+  add_foreign_key "wage_chunks", "assignments", on_delete: :cascade
 end

--- a/backend/docs/erd.svg
+++ b/backend/docs/erd.svg
@@ -13,29 +13,20 @@
 <!-- m_ActiveRecord::InternalMetadata -->
 <g id="node1" class="node">
 <title>m_ActiveRecord::InternalMetadata</title>
-<path fill="none" stroke="#000000" d="M14.5,-67C14.5,-67 167.5,-67 167.5,-67 173.5,-67 179.5,-73 179.5,-79 179.5,-79 179.5,-98 179.5,-98 179.5,-104 173.5,-110 167.5,-110 167.5,-110 14.5,-110 14.5,-110 8.5,-110 2.5,-104 2.5,-98 2.5,-98 2.5,-79 2.5,-79 2.5,-73 8.5,-67 14.5,-67"/>
-<text text-anchor="start" x="8" y="-97.2" font-family="Arial Bold" font-size="11.00" fill="#000000">ActiveRecord::InternalMetadata</text>
-<polyline fill="none" stroke="#000000" points="2.5,-90 179.5,-90 "/>
-<text text-anchor="start" x="26" y="-76.5" font-family="Arial" font-size="10.00" fill="#000000">value </text>
-<text text-anchor="start" x="53" y="-76.5" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
+<path fill="none" stroke="#000000" d="M14.5,-140C14.5,-140 167.5,-140 167.5,-140 173.5,-140 179.5,-146 179.5,-152 179.5,-152 179.5,-171 179.5,-171 179.5,-177 173.5,-183 167.5,-183 167.5,-183 14.5,-183 14.5,-183 8.5,-183 2.5,-177 2.5,-171 2.5,-171 2.5,-152 2.5,-152 2.5,-146 8.5,-140 14.5,-140"/>
+<text text-anchor="start" x="8" y="-170.2" font-family="Arial Bold" font-size="11.00" fill="#000000">ActiveRecord::InternalMetadata</text>
+<polyline fill="none" stroke="#000000" points="2.5,-163 179.5,-163 "/>
+<text text-anchor="start" x="26" y="-149.5" font-family="Arial" font-size="10.00" fill="#000000">value </text>
+<text text-anchor="start" x="53" y="-149.5" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
 </g>
 <!-- m_ActiveRecord::SchemaMigration -->
 <g id="node2" class="node">
 <title>m_ActiveRecord::SchemaMigration</title>
-<path fill="none" stroke="#000000" d="M12,-140.5C12,-140.5 170,-140.5 170,-140.5 176,-140.5 182,-146.5 182,-152.5 182,-152.5 182,-164.5 182,-164.5 182,-170.5 176,-176.5 170,-176.5 170,-176.5 12,-176.5 12,-176.5 6,-176.5 0,-170.5 0,-164.5 0,-164.5 0,-152.5 0,-152.5 0,-146.5 6,-140.5 12,-140.5"/>
-<text text-anchor="start" x="5" y="-155.7" font-family="Arial Bold" font-size="11.00" fill="#000000">ActiveRecord::SchemaMigration</text>
-</g>
-<!-- m_ActiveUser -->
-<g id="node3" class="node">
-<title>m_ActiveUser</title>
-<path fill="none" stroke="#000000" d="M31,-207C31,-207 151,-207 151,-207 157,-207 163,-213 163,-219 163,-219 163,-238 163,-238 163,-244 157,-250 151,-250 151,-250 31,-250 31,-250 25,-250 19,-244 19,-238 19,-238 19,-219 19,-219 19,-213 25,-207 31,-207"/>
-<text text-anchor="start" x="60" y="-237.2" font-family="Arial Bold" font-size="11.00" fill="#000000">ActiveUser</text>
-<polyline fill="none" stroke="#000000" points="19,-230 163,-230 "/>
-<text text-anchor="start" x="26" y="-216.5" font-family="Arial" font-size="10.00" fill="#000000">credentials </text>
-<text text-anchor="start" x="77" y="-216.5" font-family="Arial Italic" font-size="10.00" fill="#999999">text</text>
+<path fill="none" stroke="#000000" d="M12,-213.5C12,-213.5 170,-213.5 170,-213.5 176,-213.5 182,-219.5 182,-225.5 182,-225.5 182,-237.5 182,-237.5 182,-243.5 176,-249.5 170,-249.5 170,-249.5 12,-249.5 12,-249.5 6,-249.5 0,-243.5 0,-237.5 0,-237.5 0,-225.5 0,-225.5 0,-219.5 6,-213.5 12,-213.5"/>
+<text text-anchor="start" x="5" y="-228.7" font-family="Arial Bold" font-size="11.00" fill="#000000">ActiveRecord::SchemaMigration</text>
 </g>
 <!-- m_Applicant -->
-<g id="node4" class="node">
+<g id="node3" class="node">
 <title>m_Applicant</title>
 <path fill="none" stroke="#000000" d="M230,-546.5C230,-546.5 350,-546.5 350,-546.5 356,-546.5 362,-552.5 362,-558.5 362,-558.5 362,-642.5 362,-642.5 362,-648.5 356,-654.5 350,-654.5 350,-654.5 230,-654.5 230,-654.5 224,-654.5 218,-648.5 218,-642.5 218,-642.5 218,-558.5 218,-558.5 218,-552.5 224,-546.5 230,-546.5"/>
 <text text-anchor="start" x="262.5" y="-641.7" font-family="Arial Bold" font-size="11.00" fill="#000000">Applicant</text>
@@ -54,7 +45,7 @@
 <text text-anchor="start" x="255" y="-556.5" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
 </g>
 <!-- m_ApplicantDataForMatching -->
-<g id="node5" class="node">
+<g id="node4" class="node">
 <title>m_ApplicantDataForMatching</title>
 <path fill="none" stroke="#000000" d="M629,-625.5C629,-625.5 757,-625.5 757,-625.5 763,-625.5 769,-631.5 769,-637.5 769,-637.5 769,-721.5 769,-721.5 769,-727.5 763,-733.5 757,-733.5 757,-733.5 629,-733.5 629,-733.5 623,-733.5 617,-727.5 617,-721.5 617,-721.5 617,-637.5 617,-637.5 617,-631.5 623,-625.5 629,-625.5"/>
 <text text-anchor="start" x="622" y="-720.7" font-family="Arial Bold" font-size="11.00" fill="#000000">ApplicantDataForMatching</text>
@@ -78,7 +69,7 @@
 <path fill="none" stroke="#000000" d="M486.5,-603.5C531.5762,-603.8986 578.9714,-620.077 616.9708,-637.4035"/>
 </g>
 <!-- m_Application -->
-<g id="node6" class="node">
+<g id="node5" class="node">
 <title>m_Application</title>
 <path fill="none" stroke="#000000" d="M426.5,-389C426.5,-389 546.5,-389 546.5,-389 552.5,-389 558.5,-395 558.5,-401 558.5,-401 558.5,-446 558.5,-446 558.5,-452 552.5,-458 546.5,-458 546.5,-458 426.5,-458 426.5,-458 420.5,-458 414.5,-452 414.5,-446 414.5,-446 414.5,-401 414.5,-401 414.5,-395 420.5,-389 426.5,-389"/>
 <text text-anchor="start" x="454" y="-445.2" font-family="Arial Bold" font-size="11.00" fill="#000000">Application</text>
@@ -97,7 +88,7 @@
 <polygon fill="#000000" stroke="#000000" points="443.6076,-466.3754 448.1865,-458.0114 439.3911,-461.6944 443.6076,-466.3754"/>
 </g>
 <!-- m_Assignment -->
-<g id="node7" class="node">
+<g id="node6" class="node">
 <title>m_Assignment</title>
 <path fill="none" stroke="#000000" d="M633,-461.5C633,-461.5 753,-461.5 753,-461.5 759,-461.5 765,-467.5 765,-473.5 765,-473.5 765,-583.5 765,-583.5 765,-589.5 759,-595.5 753,-595.5 753,-595.5 633,-595.5 633,-595.5 627,-595.5 621,-589.5 621,-583.5 621,-583.5 621,-473.5 621,-473.5 621,-467.5 627,-461.5 633,-461.5"/>
 <text text-anchor="start" x="659" y="-582.7" font-family="Arial Bold" font-size="11.00" fill="#000000">Assignment</text>
@@ -133,7 +124,7 @@
 <polygon fill="#000000" stroke="#000000" points="616.6897,-621.1725 625.2976,-625.2747 621.1267,-616.6999 616.6897,-621.1725"/>
 </g>
 <!-- m_PositionPreference -->
-<g id="node14" class="node">
+<g id="node13" class="node">
 <title>m_PositionPreference</title>
 <path fill="none" stroke="#000000" d="M632,-363C632,-363 754,-363 754,-363 760,-363 766,-369 766,-375 766,-375 766,-420 766,-420 766,-426 760,-432 754,-432 754,-432 632,-432 632,-432 626,-432 620,-426 620,-420 620,-420 620,-375 620,-375 620,-369 626,-363 632,-363"/>
 <text text-anchor="start" x="640.5" y="-419.2" font-family="Arial Bold" font-size="11.00" fill="#000000">PositionPreference</text>
@@ -152,7 +143,7 @@
 <polygon fill="#000000" stroke="#000000" points="611.233,-410.9701 619.7689,-406.7204 610.4459,-404.7194 611.233,-410.9701"/>
 </g>
 <!-- m_Offer -->
-<g id="node10" class="node">
+<g id="node9" class="node">
 <title>m_Offer</title>
 <path fill="none" stroke="#000000" d="M823,-376.5C823,-376.5 949,-376.5 949,-376.5 955,-376.5 961,-382.5 961,-388.5 961,-388.5 961,-706.5 961,-706.5 961,-712.5 955,-718.5 949,-718.5 949,-718.5 823,-718.5 823,-718.5 817,-718.5 811,-712.5 811,-706.5 811,-706.5 811,-388.5 811,-388.5 811,-382.5 817,-376.5 823,-376.5"/>
 <text text-anchor="start" x="870" y="-705.7" font-family="Arial Bold" font-size="11.00" fill="#000000">Offer</text>
@@ -213,7 +204,7 @@
 <polygon fill="#000000" stroke="#000000" points="801.4579,-542.3423 810.7232,-540.0893 802.0751,-536.0726 801.4579,-542.3423"/>
 </g>
 <!-- m_WageChunk -->
-<g id="node18" class="node">
+<g id="node17" class="node">
 <title>m_WageChunk</title>
 <path fill="none" stroke="#000000" d="M823,-251C823,-251 949,-251 949,-251 955,-251 961,-257 961,-263 961,-263 961,-334 961,-334 961,-340 955,-346 949,-346 949,-346 823,-346 823,-346 817,-346 811,-340 811,-334 811,-334 811,-263 811,-263 811,-257 817,-251 823,-251"/>
 <text text-anchor="start" x="852" y="-333.2" font-family="Arial Bold" font-size="11.00" fill="#000000">WageChunk</text>
@@ -236,7 +227,7 @@
 <polygon fill="#000000" stroke="#000000" points="820.4338,-354.8273 824.1873,-346.0618 815.7868,-350.5734 820.4338,-354.8273"/>
 </g>
 <!-- m_ContractTemplate -->
-<g id="node8" class="node">
+<g id="node7" class="node">
 <title>m_ContractTemplate</title>
 <path fill="none" stroke="#000000" d="M230,-197C230,-197 350,-197 350,-197 356,-197 362,-203 362,-209 362,-209 362,-254 362,-254 362,-260 356,-266 350,-266 350,-266 230,-266 230,-266 224,-266 218,-260 218,-254 218,-254 218,-209 218,-209 218,-203 224,-197 230,-197"/>
 <text text-anchor="start" x="241" y="-253.2" font-family="Arial Bold" font-size="11.00" fill="#000000">ContractTemplate</text>
@@ -249,7 +240,7 @@
 <text text-anchor="start" x="284" y="-206.5" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
 </g>
 <!-- m_Position -->
-<g id="node11" class="node">
+<g id="node10" class="node">
 <title>m_Position</title>
 <path fill="none" stroke="#000000" d="M410,-238C410,-238 563,-238 563,-238 569,-238 575,-244 575,-250 575,-250 575,-347 575,-347 575,-353 569,-359 563,-359 563,-359 410,-359 410,-359 404,-359 398,-353 398,-347 398,-347 398,-250 398,-250 398,-244 404,-238 410,-238"/>
 <text text-anchor="start" x="462.5" y="-346.2" font-family="Arial Bold" font-size="11.00" fill="#000000">Position</text>
@@ -276,7 +267,7 @@
 <polygon fill="#000000" stroke="#000000" points="388.214,-268.3157 397.7491,-268.2389 390.2472,-262.3528 388.214,-268.3157"/>
 </g>
 <!-- m_Instructor -->
-<g id="node9" class="node">
+<g id="node8" class="node">
 <title>m_Instructor</title>
 <path fill="none" stroke="#000000" d="M230,-296.5C230,-296.5 350,-296.5 350,-296.5 356,-296.5 362,-302.5 362,-308.5 362,-308.5 362,-366.5 362,-366.5 362,-372.5 356,-378.5 350,-378.5 350,-378.5 230,-378.5 230,-378.5 224,-378.5 218,-372.5 218,-366.5 218,-366.5 218,-308.5 218,-308.5 218,-302.5 224,-296.5 230,-296.5"/>
 <text text-anchor="start" x="262" y="-365.7" font-family="Arial Bold" font-size="11.00" fill="#000000">Instructor</text>
@@ -304,7 +295,7 @@
 <polygon fill="#000000" stroke="#000000" points="614.2603,-456.0572 622.3714,-461.0705 619.157,-452.0932 614.2603,-456.0572"/>
 </g>
 <!-- m_PositionDataForAd -->
-<g id="node12" class="node">
+<g id="node11" class="node">
 <title>m_PositionDataForAd</title>
 <path fill="none" stroke="#000000" d="M629.5,-113C629.5,-113 756.5,-113 756.5,-113 762.5,-113 768.5,-119 768.5,-125 768.5,-125 768.5,-222 768.5,-222 768.5,-228 762.5,-234 756.5,-234 756.5,-234 629.5,-234 629.5,-234 623.5,-234 617.5,-228 617.5,-222 617.5,-222 617.5,-125 617.5,-125 617.5,-119 623.5,-113 629.5,-113"/>
 <text text-anchor="start" x="640.5" y="-221.2" font-family="Arial Bold" font-size="11.00" fill="#000000">PositionDataForAd</text>
@@ -330,7 +321,7 @@
 <path fill="none" stroke="#000000" d="M575.273,-244.7633C589.2651,-236.2935 603.6192,-227.6046 617.2796,-219.3356"/>
 </g>
 <!-- m_PositionDataForMatching -->
-<g id="node13" class="node">
+<g id="node12" class="node">
 <title>m_PositionDataForMatching</title>
 <path fill="none" stroke="#000000" d="M623,-.5C623,-.5 763,-.5 763,-.5 769,-.5 775,-6.5 775,-12.5 775,-12.5 775,-70.5 775,-70.5 775,-76.5 769,-82.5 763,-82.5 763,-82.5 623,-82.5 623,-82.5 617,-82.5 611,-76.5 611,-70.5 611,-70.5 611,-12.5 611,-12.5 611,-6.5 617,-.5 623,-.5"/>
 <text text-anchor="start" x="626" y="-69.7" font-family="Arial Bold" font-size="11.00" fill="#000000">PositionDataForMatching</text>
@@ -356,34 +347,34 @@
 <polygon fill="#000000" stroke="#000000" points="611.308,-361.8286 620.7854,-362.8789 614.0316,-356.1477 611.308,-361.8286"/>
 </g>
 <!-- m_ReportingTag -->
-<g id="node15" class="node">
+<g id="node14" class="node">
 <title>m_ReportingTag</title>
-<path fill="none" stroke="#000000" d="M628.5,-264C628.5,-264 757.5,-264 757.5,-264 763.5,-264 769.5,-270 769.5,-276 769.5,-276 769.5,-321 769.5,-321 769.5,-327 763.5,-333 757.5,-333 757.5,-333 628.5,-333 628.5,-333 622.5,-333 616.5,-327 616.5,-321 616.5,-321 616.5,-276 616.5,-276 616.5,-270 622.5,-264 628.5,-264"/>
+<path fill="none" stroke="#000000" d="M633,-264C633,-264 753,-264 753,-264 759,-264 765,-270 765,-276 765,-276 765,-321 765,-321 765,-327 759,-333 753,-333 753,-333 633,-333 633,-333 627,-333 621,-327 621,-321 621,-321 621,-276 621,-276 621,-270 627,-264 633,-264"/>
 <text text-anchor="start" x="655" y="-320.2" font-family="Arial Bold" font-size="11.00" fill="#000000">ReportingTag</text>
-<polyline fill="none" stroke="#000000" points="616.5,-313 769.5,-313 "/>
-<text text-anchor="start" x="624" y="-299.5" font-family="Arial" font-size="10.00" fill="#000000">position_id </text>
-<text text-anchor="start" x="674" y="-299.5" font-family="Arial Italic" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="624" y="-286.5" font-family="Arial" font-size="10.00" fill="#000000">wage_chunk_id </text>
-<text text-anchor="start" x="694" y="-286.5" font-family="Arial Italic" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
-<text text-anchor="start" x="624" y="-273.5" font-family="Arial" font-size="10.00" fill="#000000">name </text>
-<text text-anchor="start" x="652" y="-273.5" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
+<polyline fill="none" stroke="#000000" points="621,-313 765,-313 "/>
+<text text-anchor="start" x="628" y="-299.5" font-family="Arial" font-size="10.00" fill="#000000">position_id </text>
+<text text-anchor="start" x="678" y="-299.5" font-family="Arial Italic" font-size="10.00" fill="#999999">integer (8) FK</text>
+<text text-anchor="start" x="628" y="-286.5" font-family="Arial" font-size="10.00" fill="#000000">wage_chunk_id </text>
+<text text-anchor="start" x="698" y="-286.5" font-family="Arial Italic" font-size="10.00" fill="#999999">integer (8) FK</text>
+<text text-anchor="start" x="628" y="-273.5" font-family="Arial" font-size="10.00" fill="#000000">name </text>
+<text text-anchor="start" x="656" y="-273.5" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
 </g>
 <!-- m_Position&#45;&gt;m_ReportingTag -->
 <g id="edge2" class="edge">
 <title>m_Position&#45;&gt;m_ReportingTag</title>
-<path fill="none" stroke="#000000" d="M584.2794,-298.5C591.8425,-298.5 599.4448,-298.5 606.9234,-298.5"/>
+<path fill="none" stroke="#000000" d="M584.5737,-298.5C593.6298,-298.5 602.7391,-298.5 611.6221,-298.5"/>
 <polygon fill="#000000" stroke="#000000" points="584.273,-295.3501 575.273,-298.5 584.273,-301.6501 584.273,-295.3501"/>
-<polygon fill="#000000" stroke="#000000" points="607.318,-301.6501 616.318,-298.5 607.3179,-295.3501 607.318,-301.6501"/>
+<polygon fill="#000000" stroke="#000000" points="611.7854,-301.6501 620.7854,-298.5 611.7853,-295.3501 611.7854,-301.6501"/>
 </g>
 <!-- m_ReportingTag&#45;&gt;m_WageChunk -->
 <g id="edge18" class="edge">
 <title>m_ReportingTag&#45;&gt;m_WageChunk</title>
-<path fill="none" stroke="#000000" d="M778.8551,-298.5C786.3422,-298.5 793.9157,-298.5 801.3926,-298.5"/>
-<polygon fill="#000000" stroke="#000000" points="778.5559,-295.3501 769.5559,-298.5 778.5559,-301.6501 778.5559,-295.3501"/>
-<polygon fill="#000000" stroke="#000000" points="801.7978,-301.6501 810.7977,-298.5 801.7977,-295.3501 801.7978,-301.6501"/>
+<path fill="none" stroke="#000000" d="M774.299,-298.5C783.3562,-298.5 792.5968,-298.5 801.6906,-298.5"/>
+<polygon fill="#000000" stroke="#000000" points="774.1406,-295.3501 765.1405,-298.5 774.1405,-301.6501 774.1406,-295.3501"/>
+<polygon fill="#000000" stroke="#000000" points="801.7232,-301.6501 810.7232,-298.5 801.7232,-295.3501 801.7232,-301.6501"/>
 </g>
 <!-- m_Session -->
-<g id="node16" class="node">
+<g id="node15" class="node">
 <title>m_Session</title>
 <path fill="none" stroke="#000000" d="M31,-280C31,-280 151,-280 151,-280 157,-280 163,-286 163,-292 163,-292 163,-363 163,-363 163,-369 157,-375 151,-375 151,-375 31,-375 31,-375 25,-375 19,-369 19,-363 19,-363 19,-292 19,-292 19,-286 25,-280 31,-280"/>
 <text text-anchor="start" x="67.5" y="-362.2" font-family="Arial Bold" font-size="11.00" fill="#000000">Session</text>
@@ -419,7 +410,7 @@
 <polygon fill="#000000" stroke="#000000" points="406.7471,-366.9296 412.0842,-359.0278 402.9843,-361.8767 406.7471,-366.9296"/>
 </g>
 <!-- m_User -->
-<g id="node17" class="node">
+<g id="node16" class="node">
 <title>m_User</title>
 <path fill="none" stroke="#000000" d="M31,-405C31,-405 151,-405 151,-405 157,-405 163,-411 163,-417 163,-417 163,-462 163,-462 163,-468 157,-474 151,-474 151,-474 31,-474 31,-474 25,-474 19,-468 19,-462 19,-462 19,-417 19,-417 19,-411 25,-405 31,-405"/>
 <text text-anchor="start" x="76.5" y="-461.2" font-family="Arial Bold" font-size="11.00" fill="#000000">User</text>
@@ -432,7 +423,7 @@
 <text text-anchor="start" x="72" y="-414.5" font-family="Arial Italic" font-size="10.00" fill="#999999">datetime</text>
 </g>
 <!-- m_primary::SchemaMigration -->
-<g id="node19" class="node">
+<g id="node18" class="node">
 <title>m_primary::SchemaMigration</title>
 <path fill="none" stroke="#000000" d="M27.5,-504.5C27.5,-504.5 154.5,-504.5 154.5,-504.5 160.5,-504.5 166.5,-510.5 166.5,-516.5 166.5,-516.5 166.5,-528.5 166.5,-528.5 166.5,-534.5 160.5,-540.5 154.5,-540.5 154.5,-540.5 27.5,-540.5 27.5,-540.5 21.5,-540.5 15.5,-534.5 15.5,-528.5 15.5,-528.5 15.5,-516.5 15.5,-516.5 15.5,-510.5 21.5,-504.5 27.5,-504.5"/>
 <text text-anchor="start" x="21" y="-519.7" font-family="Arial Bold" font-size="11.00" fill="#000000">primary::SchemaMigration</text>

--- a/backend/spec/factories/reporting_tags.rb
+++ b/backend/spec/factories/reporting_tags.rb
@@ -13,8 +13,8 @@ end
 # Table name: reporting_tags
 #
 #  id            :integer          not null, primary key
-#  position_id   :integer          not null
-#  wage_chunk_id :integer          not null
+#  position_id   :integer
+#  wage_chunk_id :integer
 #  name          :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null

--- a/backend/spec/models/reporting_tag_spec.rb
+++ b/backend/spec/models/reporting_tag_spec.rb
@@ -14,8 +14,8 @@ end
 # Table name: reporting_tags
 #
 #  id            :integer          not null, primary key
-#  position_id   :integer          not null
-#  wage_chunk_id :integer          not null
+#  position_id   :integer
+#  wage_chunk_id :integer
 #  name          :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null

--- a/frontend/src/tests/api.test.js
+++ b/frontend/src/tests/api.test.js
@@ -26,13 +26,14 @@ describe("API tests", () => {
         await databaseSeeder.verifySeed(api);
     }, 30000);
 
-    describe.skip("`/admin/sessions` tests", () => {
+    describe("`/admin/sessions` tests", () => {
         sessionsTests(api);
-    });
+    }, 30000);
 
     describe("template tests", () => {
         templatesTests(api);
     });
+
     describe("`/admin/positions` tests", () => {
         positionsTests({ apiGET, apiPOST });
     });

--- a/frontend/src/tests/assignment-tests.js
+++ b/frontend/src/tests/assignment-tests.js
@@ -8,14 +8,19 @@ import {
 } from "./utils";
 import { databaseSeeder } from "./setup";
 
-export function assignmentsTests({ apiGET, apiPOST }) {
-    const session = databaseSeeder.seededData.session;
-    const applicant = databaseSeeder.seededData.applicant;
-    const assignment = databaseSeeder.seededData.assignment;
-    const contractTemplate = databaseSeeder.seededData.contractTemplate;
+export function assignmentsTests(api) {
+    const { apiGET, apiPOST } = api;
+    let session;
+    let applicant;
+    let assignment;
+    let contractTemplate;
 
     beforeAll(async () => {
-        await apiPOST("/debug/restore_snapshot");
+        await databaseSeeder.seed(api);
+        session = databaseSeeder.seededData.session;
+        applicant = databaseSeeder.seededData.applicant;
+        assignment = databaseSeeder.seededData.assignment;
+        contractTemplate = databaseSeeder.seededData.contractTemplate;
     }, 30000);
 
     it("get assignments for session", async () => {
@@ -122,4 +127,8 @@ export function assignmentsTests({ apiGET, apiPOST }) {
 
         expect(withUpdatedAssignment.length).toEqual(2);
     });
+
+    it.todo(
+        "assignments created with null start/end_date inherit the start/end_date from the parent position"
+    );
 }

--- a/frontend/src/tests/position-tests.js
+++ b/frontend/src/tests/position-tests.js
@@ -20,16 +20,14 @@ export function positionsTests(api = { apiGET, apiPOST }) {
 
     let newPosition;
 
-    // set up a session to be available before tests run
     beforeAll(async () => {
-        // this session will be available for all tests
-        await apiPOST("/debug/restore_snapshot");
+        await databaseSeeder.seed(api);
     });
 
     it("get positions for session", async () => {
         const resp1 = await apiGET(`/admin/sessions/${session.id}/positions`);
 
-        expect(resp1).toMatchObject({ status: "success" });
+        expect(resp1).toHaveStatus("success");
 
         // make sure the position we created is in that list
         expect(resp1.payload).toContainObject(position);
@@ -160,7 +158,7 @@ export function positionsTests(api = { apiGET, apiPOST }) {
         };
         // create a new session to add a template to
         const resp1 = await apiPOST("/admin/sessions", newSessionData);
-        expect(resp1).toMatchObject({ status: "success" });
+        expect(resp1).toHaveStatus("success");
         const sessionId = resp1.payload.id;
 
         // create a new position of the same code associated with new session
@@ -168,7 +166,7 @@ export function positionsTests(api = { apiGET, apiPOST }) {
             `/admin/sessions/${sessionId}/positions`,
             newPositionData2
         );
-        expect(resp2).toMatchObject({ status: "success" });
+        expect(resp2).toHaveStatus("success");
         // make sure we get back what we put in
         expect(resp2.payload).toMatchObject(newPositionData2);
 
@@ -179,5 +177,9 @@ export function positionsTests(api = { apiGET, apiPOST }) {
 
     it.todo(
         "create a position with instructors list specified and have instructors automatically added to the position"
+    );
+
+    it.todo(
+        "When the start/end_date of a position is null, the start/end_date of the sessions is returned instead"
     );
 }

--- a/frontend/src/tests/session-tests.js
+++ b/frontend/src/tests/session-tests.js
@@ -26,7 +26,7 @@ export function sessionsTests(api) {
     let session = null;
 
     beforeAll(async () => {
-        await apiPOST("/debug/restore_snapshot");
+        await databaseSeeder.seed(api);
         session = databaseSeeder.seededData.session;
     }, 30000);
 
@@ -83,7 +83,7 @@ export function sessionsTests(api) {
         const newData = { ...session, rate1: 57.75 };
         const resp1 = await apiPOST("/admin/sessions", newData);
 
-        expect(resp1).toMatchObject({ status: "success" });
+        expect(resp1).toHaveStatus("success");
         expect(resp1.payload).toMatchObject(newData);
 
         // get the sessions list and make sure we're updated there as well
@@ -110,7 +110,7 @@ export function sessionsTests(api) {
     it("throw error on update when `name` is empty", async () => {
         // update a session with invalid name
         const newData1 = { ...session, name: "" };
-        const newData2 = { ...session, name: undefined };
+        const newData2 = { ...session, name: null };
         const resp1 = await apiPOST("/admin/sessions", newData1);
 
         expect(resp1).toMatchObject({ status: "error" });
@@ -146,7 +146,7 @@ export function sessionsTests(api) {
     it("throw error when deleting item with invalid id", async () => {
         // get the max session id
         const resp1 = await apiGET("/admin/sessions");
-        expect(resp1).toMatchObject({ status: "success" });
+        expect(resp1).toHaveStatus("success");
         checkPropTypes(PropTypes.arrayOf(sessionPropTypes), resp1.payload);
         const maxId = Math.max(...resp1.payload.map(s => s.id));
 
@@ -155,6 +155,7 @@ export function sessionsTests(api) {
             id: maxId + 1 // add 1 to make the id invalid
         });
         // expected an error with non-identical session id
+        expect(resp2).toHaveStatus("error");
         expect(resp2).toMatchObject({ status: "error" });
         checkPropTypes(errorPropTypes, resp2);
 
@@ -163,7 +164,7 @@ export function sessionsTests(api) {
             id: null
         });
         // expected an error with non-identical session id
-        expect(resp3).toMatchObject({ status: "error" });
+        expect(resp3).toHaveStatus("error");
         checkPropTypes(errorPropTypes, resp3);
     });
 
@@ -171,7 +172,7 @@ export function sessionsTests(api) {
         const resp1 = await apiPOST("/admin/sessions/delete", {
             id: session.id
         });
-        expect(resp1).toMatchObject({ status: "success" });
+        expect(resp1).toHaveStatus("success");
         const { payload: withoutNewSessions } = await apiGET("/admin/sessions");
         expect(withoutNewSessions.map(x => x.id)).not.toContain(session.id);
     });

--- a/frontend/src/tests/setup.js
+++ b/frontend/src/tests/setup.js
@@ -99,6 +99,7 @@ async function seedDatabase(
     // We must first ensure there is a user with the proper permissions
     // set as the active user. Otherwise, subsequent requests will fail
     resp = await apiPOST("/debug/users", seeded.active_user);
+    expect(resp).toHaveStatus("success");
     Object.assign(seeded.active_user, resp.payload);
     await apiPOST("/debug/active_user", seeded.active_user);
 
@@ -107,6 +108,7 @@ async function seedDatabase(
     // Save the data that was returned to us. What's most important
     // is the session id. Use Object.assign so that all memory
     // references to the original seeded.session are kept intact.
+    expect(resp).toHaveStatus("success");
     Object.assign(seeded.session, resp.payload);
 
     // Contract Template
@@ -114,10 +116,12 @@ async function seedDatabase(
         `/admin/sessions/${seeded.session.id}/contract_templates`,
         seeded.contractTemplate
     );
+    expect(resp).toHaveStatus("success");
     Object.assign(seeded.contractTemplate, resp.payload);
 
     // Applicant
     resp = await apiPOST(`/admin/applicants`, seeded.applicant);
+    expect(resp).toHaveStatus("success");
     Object.assign(seeded.applicant, resp.payload);
 
     // Position
@@ -128,6 +132,7 @@ async function seedDatabase(
         `/admin/sessions/${seeded.session.id}/positions`,
         seeded.position
     );
+    expect(resp).toHaveStatus("success");
     Object.assign(seeded.position, resp.payload);
 
     // Assignment
@@ -136,13 +141,8 @@ async function seedDatabase(
         applicant_id: seeded.applicant.id
     });
     resp = await apiPOST(`/admin/assignments`, seeded.assignment);
+    expect(resp).toHaveStatus("success");
     Object.assign(seeded.assignment, resp.payload);
-
-    //
-    // Take a snapshot of the newly seeded data so we can "restore" it
-    // before each test.
-    //
-    await apiPOST("/debug/snapshot");
 }
 
 /**

--- a/frontend/src/tests/template-tests.js
+++ b/frontend/src/tests/template-tests.js
@@ -35,7 +35,7 @@ export function templatesTests(api) {
     // set up a session to be available before tests run
 
     beforeAll(async () => {
-        await apiPOST("/debug/restore_snapshot");
+        await databaseSeeder.seed(api);
         session = databaseSeeder.seededData.session;
     }, 30000);
 

--- a/frontend/src/tests/user-permission-tests.js
+++ b/frontend/src/tests/user-permission-tests.js
@@ -20,7 +20,7 @@ export function userPermissionsTests(api) {
     };
 
     beforeAll(async () => {
-        await apiPOST("/debug/restore_snapshot");
+        await databaseSeeder.seed(api);
     }, 30000);
 
     it("Admin user can access admin route", async () => {

--- a/frontend/src/tests/user-tests.js
+++ b/frontend/src/tests/user-tests.js
@@ -21,7 +21,7 @@ export function usersTests(api) {
     };
 
     beforeAll(async () => {
-        await apiPOST("/debug/restore_snapshot");
+        await databaseSeeder.seed(api);
     }, 30000);
 
     it("Fetches users", async () => {

--- a/frontend/src/tests/utils.js
+++ b/frontend/src/tests/utils.js
@@ -33,6 +33,32 @@ expect.extend({
                 pass: false
             };
         }
+    },
+    toHaveStatus(received, argument) {
+        if (received == null) {
+            throw new Error(
+                "Cannot check the status of a null/undefined response"
+            );
+        }
+        if (received.status === argument) {
+            return {
+                pass: true,
+                message: () =>
+                    `expected API response to not have ${this.utils.printExpected(
+                        {
+                            status: argument
+                        }
+                    )} but received ${this.utils.printReceived(received)}`
+            };
+        } else {
+            return {
+                pass: false,
+                message: () =>
+                    `expected API response to have ${this.utils.printExpected({
+                        status: argument
+                    })} but received ${this.utils.printReceived(received)}`
+            };
+        }
     }
 });
 


### PR DESCRIPTION
Reporting tags previously required both a wage chunk and a position. However, reporting tags can belong to just one of those. The requirement they belong to both is removed.

Tests have been refactored to reseed the database every time instead of restoring data. This is a workaround because `restore_snapshot` behaves in unexpected ways.