### PR TITLE
Added `offers` to backend

### DIFF
--- a/backend/app/models/assignment.rb
+++ b/backend/app/models/assignment.rb
@@ -6,8 +6,8 @@ class Assignment < ApplicationRecord
     ACTIVE_OFFER_STATUS = %i[pending accepted rejected withdrawn].freeze
     enum active_offer_status: ACTIVE_OFFER_STATUS
 
-    has_many :offers
-    has_many :wage_chunks, dependent: :delete_all
+    has_many :offers, dependent: :destroy
+    has_many :wage_chunks, dependent: :destroy
     belongs_to :active_offer, class_name: 'Offer', optional: true
     belongs_to :applicant
     belongs_to :position

--- a/backend/app/models/instructor.rb
+++ b/backend/app/models/instructor.rb
@@ -5,6 +5,15 @@ class Instructor < ApplicationRecord
 
     validates_presence_of :last_name, :first_name, :utorid
     validates_uniqueness_of :utorid
+
+    # Returns a formatted string displaying the instructor's contact information
+    def contact_info
+        if email?
+            "#{first_name} #{last_name} <#{email}>"
+        else
+            "#{first_name} #{last_name}"
+        end
+    end
 end
 
 # == Schema Information

--- a/backend/app/serializers/offer_serializer.rb
+++ b/backend/app/serializers/offer_serializer.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-class OfferSerializer < ApplicationSerializer
+class OfferSerializer < ActiveModel::Serializer
     attributes :id,
+               :assignment_id,
                :first_name,
                :last_name,
                :email,
@@ -15,9 +16,12 @@ class OfferSerializer < ApplicationSerializer
                :installments,
                :ta_coordinator_name,
                :ta_coordinator_email,
+               :signature,
                :emailed_date,
                :accepted_date,
                :rejected_date,
                :withdrawn_date,
+               :url_token,
+               :nag_count,
                :status
 end


### PR DESCRIPTION
This PR populates the `instructor_contact_desc` and the `pay_period_desc` fields of an offer.

It also addresses issue #351 