### PR TITLE
Positions improvements

### DIFF
--- a/frontend/src/components/components.css
+++ b/frontend/src/components/components.css
@@ -17,3 +17,7 @@
     border-radius: 15px;
     border: 2px solid rgb(0, 95, 204);
 }
+
+.toggle-button.active {
+    font-weight: bold;
+}

--- a/frontend/src/components/positions-list.js
+++ b/frontend/src/components/positions-list.js
@@ -40,6 +40,65 @@ const DEFAULT_COLUMNS = [
         accessor: "contract_template.template_name",
     },
 ];
+function getPreferenceLevelColor(preferenceLevel) {
+    return ["danger", "warning", "primary", "info", "success"][
+        preferenceLevel + 1
+    ];
+}
+const ADVANCED_COLUMNS = [
+    {
+        Header: "Duties",
+        accessor: "duties",
+    },
+    {
+        Header: "Instructor Preferences",
+        accessor: "instructor_preferences",
+        Cell: (props) => (
+            <React.Fragment>
+                {props.value.map((preference = {}, index) => {
+                    const name = `${preference.instructor.first_name} ${preference.instructor.last_name}`;
+                    return (
+                        <Badge
+                            variant={getPreferenceLevelColor(
+                                preference.preference_level
+                            )}
+                            className="mr-1"
+                            key={`${name}-${index}`}
+                        >
+                            {name}
+                        </Badge>
+                    );
+                })}
+            </React.Fragment>
+        ),
+    },
+    {
+        Header: "Qualifications",
+        accessor: "qualifications",
+    },
+    {
+        Header: "Enrollment",
+        accessor: "current_enrollment",
+        Cell: (row) => {
+            console.log("row", row);
+            const na = "N/A";
+            const {
+                current_enrollment = na,
+                current_waitlisted = na,
+                id,
+            } = row.row;
+
+            return (
+                <React.Fragment>
+                    <p key={id}>
+                        Enrolled: {current_enrollment} Waitlisted:{" "}
+                        {current_waitlisted}
+                    </p>
+                </React.Fragment>
+            );
+        },
+    },
+];
 
 /**
  * List the instructors using a ReactTable. `columns` can be passed
@@ -50,13 +109,19 @@ const DEFAULT_COLUMNS = [
  * @returns
  */
 export function PositionsList(props) {
-    const { positions, columns = DEFAULT_COLUMNS } = props;
+    const { positions, columns = DEFAULT_COLUMNS, view } = props;
+    if (view === "advanced") columns.concat(ADVANCED_COLUMNS);
+    console.log(positions);
     return (
         <React.Fragment>
             <h3>Positions</h3>
             <ReactTable
                 data={positions}
-                columns={columns}
+                columns={
+                    view === "advanced"
+                        ? columns.concat(ADVANCED_COLUMNS)
+                        : columns
+                }
                 showPagination={false}
                 minRows={1}
             />

--- a/frontend/src/components/positions-list.js
+++ b/frontend/src/components/positions-list.js
@@ -2,7 +2,13 @@ import React from "react";
 import PropTypes from "prop-types";
 import ReactTable from "react-table";
 import { docApiPropTypes } from "../api/defs/doc-generation";
-import { Badge } from "react-bootstrap";
+import {
+    Badge,
+    Row,
+    ToggleButtonGroup,
+    ButtonToolbar,
+    Button,
+} from "react-bootstrap";
 import { formatDate } from "../libs/utils";
 
 const DEFAULT_COLUMNS = [
@@ -80,7 +86,6 @@ const ADVANCED_COLUMNS = [
         Header: "Enrollment",
         accessor: "current_enrollment",
         Cell: (row) => {
-            console.log("row", row);
             const na = "N/A";
             const {
                 current_enrollment = na,
@@ -109,9 +114,16 @@ const ADVANCED_COLUMNS = [
  * @returns
  */
 export function PositionsList(props) {
-    const { positions, columns = DEFAULT_COLUMNS, view } = props;
+    const {
+        positions,
+        columns = DEFAULT_COLUMNS,
+        view,
+        viewableColumns,
+        setViewableColumns,
+    } = props;
     if (view === "advanced") columns.concat(ADVANCED_COLUMNS);
-    console.log(positions);
+    const headings = getFetchedColumnHeadings(positions);
+    // if (viewableColumns !== headings) setViewableColumns(headings);
     return (
         <React.Fragment>
             <h3>Positions</h3>

--- a/frontend/src/components/positions-list.js
+++ b/frontend/src/components/positions-list.js
@@ -2,26 +2,33 @@ import React from "react";
 import PropTypes from "prop-types";
 import ReactTable from "react-table";
 import { docApiPropTypes } from "../api/defs/doc-generation";
-import {
-    Badge,
-    Row,
-    ToggleButtonGroup,
-    ButtonToolbar,
-    Button,
-} from "react-bootstrap";
-import { formatDate } from "../libs/utils";
+import { Badge } from "react-bootstrap";
+import { formatDate, formatColumnName } from "../libs/utils";
 
-const DEFAULT_COLUMNS = [
-    { Header: "Position Code", accessor: "position_code" },
-    { Header: "Position Title", accessor: "position_title" },
-    { Header: "Hours", accessor: "hours_per_assignment" },
+const ALL_COLUMNS = [
     {
-        Header: "Start",
+        Header: "ID",
+        accessor: "id",
+    },
+    {
+        Header: "Position Code",
+        accessor: "position_code",
+    },
+    {
+        Header: "Position Title",
+        accessor: "position_title",
+    },
+    {
+        Header: "Hours Per Assignment",
+        accessor: "hours_per_assignment",
+    },
+    {
+        Header: "Start Date",
         accessor: "start_date",
         Cell: (row) => formatDate(row.value),
     },
     {
-        Header: "End",
+        Header: "End Date",
         accessor: "end_date",
         Cell: (row) => formatDate(row.value),
     },
@@ -45,13 +52,6 @@ const DEFAULT_COLUMNS = [
         Header: "Contract Template",
         accessor: "contract_template.template_name",
     },
-];
-function getPreferenceLevelColor(preferenceLevel) {
-    return ["danger", "warning", "primary", "info", "success"][
-        preferenceLevel + 1
-    ];
-}
-const ADVANCED_COLUMNS = [
     {
         Header: "Duties",
         accessor: "duties",
@@ -71,7 +71,7 @@ const ADVANCED_COLUMNS = [
                             className="mr-1"
                             key={`${name}-${index}`}
                         >
-                            {name}
+                            {name}: {preference.preference_level}
                         </Badge>
                     );
                 })}
@@ -83,27 +83,49 @@ const ADVANCED_COLUMNS = [
         accessor: "qualifications",
     },
     {
-        Header: "Enrollment",
+        Header: "Current Enrollment",
         accessor: "current_enrollment",
-        Cell: (row) => {
-            const na = "N/A";
-            const {
-                current_enrollment = na,
-                current_waitlisted = na,
-                id,
-            } = row.row;
-
-            return (
-                <React.Fragment>
-                    <p key={id}>
-                        Enrolled: {current_enrollment} Waitlisted:{" "}
-                        {current_waitlisted}
-                    </p>
-                </React.Fragment>
-            );
-        },
     },
+    {
+        Header: "Current Waitlisted",
+        accessor: "current_waitlisted",
+    },
+    {
+        Header: "Ad Hours Per Assignment",
+        accessor: "ad_hours_per_assignment",
+    },
+    {
+        Header: "Ad Number of Assignments",
+        accessor: "ad_num_assignments",
+    },
+    {
+        Header: "Ad Open Date",
+        accessor: "ad_open_date",
+        Cell: (row) => (row.value ? formatDate(row.value) : ""),
+    },
+    {
+        Header: "Ad Close Date",
+        accessor: "ad_close_date",
+        Cell: (row) => (row.value ? formatDate(row.value) : ""),
+    },
+    {
+        Header: "Desired Number of Assignments",
+        accessor: "desired_num_assignments",
+    },
+    // TODO: probably missing some. compare with api docs for /get/position
 ];
+
+function getPreferenceLevelColor(preferenceLevel) {
+    return ["danger", "warning", "primary", "info", "success"][
+        preferenceLevel + 1
+    ];
+}
+
+function getCustomColumns(selectedColumns) {
+    return ALL_COLUMNS.filter((column) =>
+        selectedColumns.has(formatColumnName(column.accessor))
+    );
+}
 
 /**
  * List the instructors using a ReactTable. `columns` can be passed
@@ -114,26 +136,13 @@ const ADVANCED_COLUMNS = [
  * @returns
  */
 export function PositionsList(props) {
-    const {
-        positions,
-        columns = DEFAULT_COLUMNS,
-        view,
-        viewableColumns,
-        setViewableColumns,
-    } = props;
-    if (view === "advanced") columns.concat(ADVANCED_COLUMNS);
-    const headings = getFetchedColumnHeadings(positions);
-    // if (viewableColumns !== headings) setViewableColumns(headings);
+    const { positions, selectedColumns } = props;
     return (
         <React.Fragment>
             <h3>Positions</h3>
             <ReactTable
                 data={positions}
-                columns={
-                    view === "advanced"
-                        ? columns.concat(ADVANCED_COLUMNS)
-                        : columns
-                }
+                columns={getCustomColumns(selectedColumns)}
                 showPagination={false}
                 minRows={1}
             />

--- a/frontend/src/libs/utils.js
+++ b/frontend/src/libs/utils.js
@@ -26,3 +26,7 @@ export function formatDate(dateString) {
         day: "numeric",
     })}`;
 }
+
+export function formatColumnName(column) {
+    return column.replace(/_/gi, " ");
+}

--- a/frontend/src/views/positions/index.js
+++ b/frontend/src/views/positions/index.js
@@ -1,19 +1,52 @@
 import React from "react";
 import { ConnectedAddPositionDialog } from "./add-position-dialog";
-import { Button } from "react-bootstrap";
+import {
+    Button,
+    ButtonToolbar,
+    ButtonGroup,
+    ToggleButtonGroup,
+    ToggleButton,
+} from "react-bootstrap";
 import { ConnectedPositionsList } from "./position-list";
 
 export function AdminPositionsView() {
     const [addDialogVisible, setAddDialogVisible] = React.useState(false);
+    const [advancedView, setAdvancedView] = React.useState("simple");
     return (
         <div>
-            <Button
-                onClick={() => {
-                    setAddDialogVisible(true);
-                }}
-            >
-                Add Position
-            </Button>
+            <ButtonToolbar className="d-flex justify-content-between px-3 py-2">
+                <ButtonGroup>
+                    <Button
+                        onClick={() => {
+                            setAddDialogVisible(true);
+                        }}
+                    >
+                        Add Position
+                    </Button>
+                </ButtonGroup>
+                <ToggleButtonGroup
+                    type="radio"
+                    value={advancedView}
+                    name="advancedView"
+                    onChange={(val) => setAdvancedView(val)}
+                >
+                    <ToggleButton
+                        className="toggle-button"
+                        value="simple"
+                        variant="light"
+                    >
+                        Simple View
+                    </ToggleButton>
+                    <ToggleButton
+                        className="toggle-button"
+                        value="advanced"
+                        variant="light"
+                    >
+                        Advanced View
+                    </ToggleButton>
+                </ToggleButtonGroup>
+            </ButtonToolbar>
+
             <ConnectedAddPositionDialog
                 show={addDialogVisible}
                 onHide={() => {

--- a/frontend/src/views/positions/index.js
+++ b/frontend/src/views/positions/index.js
@@ -1,59 +1,35 @@
 import React from "react";
 import { ConnectedAddPositionDialog } from "./add-position-dialog";
 import {
-    Button,
-    ButtonToolbar,
-    ButtonGroup,
-    ToggleButtonGroup,
-    ToggleButton,
-} from "react-bootstrap";
-import { ConnectedPositionsList } from "./position-list";
+    ConnectedPositionsList,
+    ConnectedPositionsListToolbar,
+} from "./position-list";
 
 export function AdminPositionsView() {
-    const [addDialogVisible, setAddDialogVisible] = React.useState(false);
     const [advancedView, setAdvancedView] = React.useState("simple");
+    const [viewableColumns, setViewableColumns] = React.useState(new Set());
+    const [selectedColumns, setSelectedColumns] = React.useState(
+        viewableColumns
+    );
+
     return (
         <div>
-            <ButtonToolbar className="d-flex justify-content-between px-3 py-2">
-                <ButtonGroup>
-                    <Button
-                        onClick={() => {
-                            setAddDialogVisible(true);
-                        }}
-                    >
-                        Add Position
-                    </Button>
-                </ButtonGroup>
-                <ToggleButtonGroup
-                    type="radio"
-                    value={advancedView}
-                    name="advancedView"
-                    onChange={(val) => setAdvancedView(val)}
-                >
-                    <ToggleButton
-                        className="toggle-button"
-                        value="simple"
-                        variant="light"
-                    >
-                        Simple View
-                    </ToggleButton>
-                    <ToggleButton
-                        className="toggle-button"
-                        value="advanced"
-                        variant="light"
-                    >
-                        Advanced View
-                    </ToggleButton>
-                </ToggleButtonGroup>
-            </ButtonToolbar>
-
-            <ConnectedAddPositionDialog
+            {/** <ConnectedAddPositionDialog
                 show={addDialogVisible}
                 onHide={() => {
                     setAddDialogVisible(false);
                 }}
+            />**/}
+            <ConnectedPositionsListToolbar
+                advancedView={advancedView}
+                setAdvancedView={setAdvancedView}
+                setViewableColumns={setViewableColumns}
+                setSelectedColumns={setSelectedColumns}
             />
-            <ConnectedPositionsList view={advancedView} />
+            <ConnectedPositionsList
+                view={advancedView}
+                viewableColumns={selectedColumns}
+            />
         </div>
     );
 }

--- a/frontend/src/views/positions/index.js
+++ b/frontend/src/views/positions/index.js
@@ -6,30 +6,32 @@ import {
 } from "./position-list";
 
 export function AdminPositionsView() {
+    const defaultColumns = new Set(
+        [
+            "position code",
+            "position title",
+            "hours",
+            "start date",
+            "end date",
+            "instructors",
+            "contract template",
+        ].map((column) => column.toLowerCase())
+    );
     const [advancedView, setAdvancedView] = React.useState("simple");
-    const [viewableColumns, setViewableColumns] = React.useState(new Set());
     const [selectedColumns, setSelectedColumns] = React.useState(
-        viewableColumns
+        defaultColumns
     );
 
     return (
         <div>
-            {/** <ConnectedAddPositionDialog
-                show={addDialogVisible}
-                onHide={() => {
-                    setAddDialogVisible(false);
-                }}
-            />**/}
             <ConnectedPositionsListToolbar
+                defaultColumns={defaultColumns}
                 advancedView={advancedView}
                 setAdvancedView={setAdvancedView}
-                setViewableColumns={setViewableColumns}
                 setSelectedColumns={setSelectedColumns}
+                selectedColumns={selectedColumns}
             />
-            <ConnectedPositionsList
-                view={advancedView}
-                viewableColumns={selectedColumns}
-            />
+            <ConnectedPositionsList selectedColumns={selectedColumns} />
         </div>
     );
 }

--- a/frontend/src/views/positions/index.js
+++ b/frontend/src/views/positions/index.js
@@ -53,7 +53,7 @@ export function AdminPositionsView() {
                     setAddDialogVisible(false);
                 }}
             />
-            <ConnectedPositionsList />
+            <ConnectedPositionsList view={advancedView} />
         </div>
     );
 }

--- a/frontend/src/views/positions/position-list.js
+++ b/frontend/src/views/positions/position-list.js
@@ -1,7 +1,12 @@
 import { connect } from "react-redux";
 import { positionsSelector } from "../../api/actions";
 import { PositionsList } from "../../components/positions-list";
+import { PositionsListToolbar } from "./positions-list-toolbar";
 
 export const ConnectedPositionsList = connect((state) => ({
     positions: positionsSelector(state),
 }))(PositionsList);
+
+export const ConnectedPositionsListToolbar = connect((state) => ({
+    positions: positionsSelector(state),
+}))(PositionsListToolbar);

--- a/frontend/src/views/positions/positions-list-toolbar.js
+++ b/frontend/src/views/positions/positions-list-toolbar.js
@@ -1,13 +1,10 @@
 import React from "react";
-import { connect } from "react-redux";
-import { positionsSelector } from "../../api/actions";
 import { formatColumnName } from "../../libs/utils";
 import { ConnectedAddPositionDialog } from "./add-position-dialog";
 import {
     Badge,
     Button,
     ButtonToolbar,
-    ButtonGroup,
     ToggleButton,
     ToggleButtonGroup,
 } from "react-bootstrap";

--- a/frontend/src/views/positions/positions-list-toolbar.js
+++ b/frontend/src/views/positions/positions-list-toolbar.js
@@ -11,6 +11,13 @@ import {
 
 const BLACKLIST = ["instructor_preferences"]; // Any fields here will not be accessible in the column selector.
 
+/**
+ * Builds an array (with no duplicates) of all column headings which appear at least once in the positions data from the database
+ * All headings which are present in the blacklist (defined above) are removed from this list
+ *
+ * @param {*} positions the positions data which was returned from a GET request to the admin/positions endpoint.
+ * @returns an array with no duplicates containing headings in the format [a-z][a-z]*_[a-z]*
+ */
 function getFetchedColumnHeadings(positions) {
     return [
         ...new Set(
@@ -24,6 +31,12 @@ function getFetchedColumnHeadings(positions) {
     ];
 }
 
+/**
+ * Builds an array of ToggleButton elements for use in the column selector component.
+ *
+ * @param {*} viewableColumns an array of all viewable column names imported from the database in the form [a-z][a-z]*_[a-z]*
+ * @param {*} selectedColumns a set of the the column names which are selected (currently being displayed)
+ */
 function getColumnSelector(viewableColumns, selectedColumns) {
     return viewableColumns.map((heading) => {
         const lowercase = formatColumnName(heading).toLowerCase();
@@ -50,7 +63,11 @@ function getColumnSelector(viewableColumns, selectedColumns) {
         );
     });
 }
-
+/**
+ * A toolbar containing the add position button, the columns selector, and the simple/advanced view toggle button
+ *
+ * @param {*} props
+ */
 export function PositionsListToolbar(props) {
     const [addDialogVisible, setAddDialogVisible] = React.useState(false);
     const {
@@ -95,8 +112,7 @@ export function PositionsListToolbar(props) {
                     {isAdvanced &&
                         getColumnSelector(
                             getFetchedColumnHeadings(positions),
-                            selectedColumns,
-                            setSelectedColumns
+                            selectedColumns
                         )}
                 </ToggleButtonGroup>
                 <ToggleButtonGroup

--- a/frontend/src/views/positions/positions-list-toolbar.js
+++ b/frontend/src/views/positions/positions-list-toolbar.js
@@ -9,13 +9,17 @@ import {
     ToggleButtonGroup,
 } from "react-bootstrap";
 
+const BLACKLIST = ["instructor_preferences"]; // Any fields here will not be accessible in the column selector.
+
 function getFetchedColumnHeadings(positions) {
     return [
         ...new Set(
-            positions.reduce(
-                (acc, position) => [...acc, ...Object.keys(position)],
-                []
-            )
+            positions
+                .reduce(
+                    (acc, position) => [...acc, ...Object.keys(position)],
+                    []
+                )
+                .filter((heading) => !BLACKLIST.includes(heading))
         ),
     ];
 }

--- a/frontend/src/views/positions/positions-list-toolbar.js
+++ b/frontend/src/views/positions/positions-list-toolbar.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { connect } from "react-redux";
 import { positionsSelector } from "../../api/actions";
+import { formatColumnName } from "../../libs/utils";
 import { ConnectedAddPositionDialog } from "./add-position-dialog";
 import {
     Badge,
@@ -22,17 +23,44 @@ function getFetchedColumnHeadings(positions) {
     ];
 }
 
+function getColumnSelector(viewableColumns, selectedColumns) {
+    return viewableColumns.map((heading) => {
+        const lowercase = formatColumnName(heading).toLowerCase();
+        const isSelected = selectedColumns.has(lowercase);
+
+        return (
+            <ToggleButton
+                type="checkbox"
+                value={lowercase}
+                key={lowercase}
+                variant="light"
+                size="sm"
+                className="text-left font-weight-lighter text-capitalize text-nowrap flex-grow-0  m-1"
+            >
+                {formatColumnName(heading)}
+                <Badge
+                    variant={
+                        isSelected ? "outline-primary" : "outline-secondary"
+                    }
+                >
+                    {isSelected ? "✓" : "❌"}
+                </Badge>
+            </ToggleButton>
+        );
+    });
+}
+
 export function PositionsListToolbar(props) {
     const [addDialogVisible, setAddDialogVisible] = React.useState(false);
     const {
         positions,
+        defaultColumns,
         advancedView,
         setAdvancedView,
-        setViewableColumns,
+        selectedColumns,
         setSelectedColumns,
     } = props;
-    console.log(props);
-    const selectedColumns = [];
+    const isAdvanced = advancedView === "advanced";
 
     return (
         <React.Fragment>
@@ -52,27 +80,35 @@ export function PositionsListToolbar(props) {
                 <ToggleButtonGroup
                     type="checkbox"
                     value={selectedColumns}
+                    onChange={(e) => {
+                        if (selectedColumns.has(e[1])) {
+                            selectedColumns.delete(e[1]);
+                        } else {
+                            selectedColumns.add(e[1]);
+                        }
+                        setSelectedColumns(new Set(selectedColumns));
+                    }}
                     name="selectedColumns"
-                    className="d-flex align-content-center flex-wrap mx-3"
+                    className="d-flex align-content-center align-self-center flex-wrap mx-3"
                 >
-                    {getFetchedColumnHeadings(positions).map((heading) => (
-                        <ToggleButton
-                            type="checkbox"
-                            value={heading}
-                            variant="light"
-                            size="sm"
-                            className="text-left font-weight-lighter text-capitalize text-nowrap flex-grow-0 flex-shrink-1"
-                        >
-                            {heading.replace(/_/gi, " ")}
-                        </ToggleButton>
-                    ))}
+                    {isAdvanced &&
+                        getColumnSelector(
+                            getFetchedColumnHeadings(positions),
+                            selectedColumns,
+                            setSelectedColumns
+                        )}
                 </ToggleButtonGroup>
                 <ToggleButtonGroup
                     className="align-self-center"
                     type="radio"
                     value={advancedView}
                     name="advancedView"
-                    onChange={(val) => setAdvancedView(val)}
+                    onChange={(val) => {
+                        if (val === "simple") {
+                            setSelectedColumns(defaultColumns);
+                        }
+                        setAdvancedView(val);
+                    }}
                 >
                     <ToggleButton
                         className="toggle-button text-nowrap"

--- a/frontend/src/views/positions/positions-list-toolbar.js
+++ b/frontend/src/views/positions/positions-list-toolbar.js
@@ -36,7 +36,7 @@ function getColumnSelector(viewableColumns, selectedColumns) {
                 key={lowercase}
                 variant="light"
                 size="sm"
-                className="text-left font-weight-lighter text-capitalize text-nowrap flex-grow-0  m-1"
+                className="text-left font-weight-lighter text-capitalize text-nowrap flex-grow-0 m-1"
             >
                 {formatColumnName(heading)}
                 <Badge

--- a/frontend/src/views/positions/positions-list-toolbar.js
+++ b/frontend/src/views/positions/positions-list-toolbar.js
@@ -1,0 +1,95 @@
+import React from "react";
+import { connect } from "react-redux";
+import { positionsSelector } from "../../api/actions";
+import { ConnectedAddPositionDialog } from "./add-position-dialog";
+import {
+    Badge,
+    Button,
+    ButtonToolbar,
+    ButtonGroup,
+    ToggleButton,
+    ToggleButtonGroup,
+} from "react-bootstrap";
+
+function getFetchedColumnHeadings(positions) {
+    return [
+        ...new Set(
+            positions.reduce(
+                (acc, position) => [...acc, ...Object.keys(position)],
+                []
+            )
+        ),
+    ];
+}
+
+export function PositionsListToolbar(props) {
+    const [addDialogVisible, setAddDialogVisible] = React.useState(false);
+    const {
+        positions,
+        advancedView,
+        setAdvancedView,
+        setViewableColumns,
+        setSelectedColumns,
+    } = props;
+    console.log(props);
+    const selectedColumns = [];
+
+    return (
+        <React.Fragment>
+            <ConnectedAddPositionDialog
+                show={addDialogVisible}
+                onHide={() => setAddDialogVisible(false)}
+            />
+            <ButtonToolbar className="d-flex justify-content-between flex-nowrap px-3 py-2">
+                <Button
+                    className="text-nowrap align-self-center"
+                    onClick={() => {
+                        setAddDialogVisible(true);
+                    }}
+                >
+                    Add Position
+                </Button>
+                <ToggleButtonGroup
+                    type="checkbox"
+                    value={selectedColumns}
+                    name="selectedColumns"
+                    className="d-flex align-content-center flex-wrap mx-3"
+                >
+                    {getFetchedColumnHeadings(positions).map((heading) => (
+                        <ToggleButton
+                            type="checkbox"
+                            value={heading}
+                            variant="light"
+                            size="sm"
+                            className="text-left font-weight-lighter text-capitalize text-nowrap flex-grow-0 flex-shrink-1"
+                        >
+                            {heading.replace(/_/gi, " ")}
+                        </ToggleButton>
+                    ))}
+                </ToggleButtonGroup>
+                <ToggleButtonGroup
+                    className="align-self-center"
+                    type="radio"
+                    value={advancedView}
+                    name="advancedView"
+                    onChange={(val) => setAdvancedView(val)}
+                >
+                    <ToggleButton
+                        className="toggle-button text-nowrap"
+                        value="simple"
+                        variant="light"
+                    >
+                        Simple View
+                    </ToggleButton>
+                    <ToggleButton
+                        className="toggle-button text-nowrap"
+                        value="advanced"
+                        variant="light"
+                    >
+                        Advanced View
+                    </ToggleButton>
+                </ToggleButtonGroup>
+            </ButtonToolbar>
+        </React.Fragment>
+    );
+}


### PR DESCRIPTION
<h1>More details in Positions page</h1>

<h2>This PR addresses some points from Issue #376:</h2>
- `Positions` A sophisticated view (the spreadsheed doesn't and shouldn't include duties, etc., but we need to be able to see/edit those fields).
- `Positions` Show `total number of hours`, `enrollment`, `waitlist`, and `number of TAs currently assigned`

<h3>New features:</h3>

- <h4>Simple/Advanced Toggle</h4>
 
  - Simple view shows position code, position title, hours, start/end dates and instructors.

  - Advanced view loads all columns which have at least 1 piece of data in them for the current session
    - Displays a button toolbar which shows which columns are enabled and disabled currently
    - Users can choose which columns they want to display
    - If the user switches back to simple mode, only the selected columns revert to default
 - All information from the database can be displayed in the table if the user chooses to enable all columns
    - ~Color coding for `instructor_preference_level`~

I will write documentation for this code tomorrow.