### PR TITLE
fixed name text overflow

### DIFF
--- a/frontend/src/components/forms/session-editor.js
+++ b/frontend/src/components/forms/session-editor.js
@@ -19,6 +19,8 @@ export function SessionEditor(props) {
         <Form>
             <DialogRow>
                 {createFieldEditor("Session Name (e.g. 2019 Fall)", "name")}
+            </DialogRow>
+            <DialogRow>
                 {createFieldEditor("Start Date", "start_date", "date")}
                 {createFieldEditor("End Date", "end_date", "date")}
             </DialogRow>


### PR DESCRIPTION
The `Add Session` dialog had an overflow issue with the titles for one of the fields. This PR moves that field to its own `<DialogRow>` component so that there is no more overflow.
![old](https://user-images.githubusercontent.com/30083877/87723264-9440ab80-c787-11ea-8c3d-e326287e5825.png)

![new](https://user-images.githubusercontent.com/30083877/87723231-7e32eb00-c787-11ea-9ce6-729a57e5e832.png)
