### PR TITLE
Edit ddah typo fix

### DIFF
--- a/frontend/src/components/components.css
+++ b/frontend/src/components/components.css
@@ -97,3 +97,12 @@
 .input-row-icon {
     align-self: center;
 }
+
+.form-row .input-row-icon {
+    margin-top: 16px;
+}
+
+.add-duty-btn-icon {
+    margin-right: 0.8em;
+    margin-bottom: 0.3em;
+}

--- a/frontend/src/components/ddahs.tsx
+++ b/frontend/src/components/ddahs.tsx
@@ -130,7 +130,7 @@ export function DdahEditor(props: {
     // If the assignment is editable, we have a selector for the assignments,
     // otherwise it is rendered as fixed text.
     let assignmentNode: React.ReactNode = ddah.assignment
-        ? `${ddah.assignment.position.position_code} for ${ddah.assignment.applicant.last_name}, ${ddah.assignment.applicant.first_name}`
+        ? ` ${ddah.assignment.position.position_code} for ${ddah.assignment.applicant.last_name}, ${ddah.assignment.applicant.first_name}`
         : "No Assignment";
     if (editableAssignment) {
         assignmentNode = (

--- a/frontend/src/components/ddahs.tsx
+++ b/frontend/src/components/ddahs.tsx
@@ -245,7 +245,7 @@ export function DdahEditor(props: {
                         })
                     }
                 >
-                    <FaPlus className="mr-2" />
+                    <FaPlus className="add-duty-btn-icon" />
                     Add Duty
                 </Button>
             </DialogRow>

--- a/frontend/src/views/ddah-table/index.tsx
+++ b/frontend/src/views/ddah-table/index.tsx
@@ -408,7 +408,7 @@ export function ConnectedDdahsTable() {
             Header: "Preview",
             accessor: "id",
             Cell: WrappedPreviewCell,
-            maxWidth: 50,
+            maxWidth: 52,
         },
         { Header: "Position", accessor: "position_code" },
         { Header: "Last Name", accessor: "last_name" },


### PR DESCRIPTION
There were a couple of tiny visual bugs in the Edit DDAH modal that I noticed during my presentation.
1. There was a space missing between Assignment and <position code>
2. The delete duty button was offset from the rest of the row.

This PR fixes those issues.