### PR TITLE
ReactTables now display all rows

### DIFF
--- a/frontend/src/components/applicants.tsx
+++ b/frontend/src/components/applicants.tsx
@@ -40,11 +40,13 @@ export function ApplicantsList(props: {
     columns?: any[];
 }) {
     const { applicants, columns = DEFAULT_COLUMNS } = props;
+    const pageSize = applicants?.length || 20;
     return (
         <ReactTable
             data={applicants}
             columns={columns}
             showPagination={false}
+            defaultPageSize={pageSize}
             minRows={1}
         />
     );

--- a/frontend/src/components/assignments-list.js
+++ b/frontend/src/components/assignments-list.js
@@ -39,6 +39,7 @@ export function AssignmentsDiffList({ modifiedAssignments }) {
 
 function AssignmentsList(props) {
     const { assignments, columns = DEFAULT_COLUMNS } = props;
+    const pageSize = assignments?.length || 20;
     return (
         <React.Fragment>
             <h3>Assignments</h3>
@@ -46,6 +47,7 @@ function AssignmentsList(props) {
                 data={assignments}
                 columns={columns}
                 showPagination={false}
+                defaultPageSize={pageSize}
                 minRows={1}
             />
         </React.Fragment>

--- a/frontend/src/components/contract-templates-list.js
+++ b/frontend/src/components/contract-templates-list.js
@@ -21,11 +21,13 @@ const DEFAULT_COLUMNS = [
  */
 export function ContractTemplatesList(props) {
     const { contractTemplates, columns = DEFAULT_COLUMNS } = props;
+    const pageSize = contractTemplates?.length || 20;
     return (
         <ReactTable
             data={contractTemplates}
             columns={columns}
             showPagination={false}
+            defaultPageSize={pageSize}
             minRows={1}
         />
     );

--- a/frontend/src/components/ddahs.tsx
+++ b/frontend/src/components/ddahs.tsx
@@ -86,11 +86,14 @@ export function DdahsList(props: {
         return { ...ddah, duties: ddahDutiesToString(ddah.duties) };
     });
 
+    const pageSize = flattenedDdahs?.length || 20;
+
     return (
         <ReactTable
             data={flattenedDdahs}
             columns={columns}
             showPagination={false}
+            defaultPageSize={pageSize}
             minRows={1}
         />
     );

--- a/frontend/src/components/filterable-table.js
+++ b/frontend/src/components/filterable-table.js
@@ -165,6 +165,7 @@ function FilterableTable(props) {
         }
     }
 
+    const pageSize = filteredData?.length || 20;
     let tableComponent = (
         <SelectTable
             ref={(r) => (reactTableRef = r)}
@@ -176,8 +177,9 @@ function FilterableTable(props) {
             isSelected={isSelected}
             selectType="checkbox"
             keyField="id"
-            minRows={1}
             showPagination={false}
+            defaultPageSize={pageSize}
+            minRows={1}
         />
     );
     // if `selected` was not passed in, the table rows should not be selectable

--- a/frontend/src/components/instructors.js
+++ b/frontend/src/components/instructors.js
@@ -23,12 +23,14 @@ const DEFAULT_COLUMNS = [
  */
 export function InstructorsList(props) {
     const { instructors, columns = DEFAULT_COLUMNS } = props;
+    const pageSize = instructors?.length || 20;
     return (
         <React.Fragment>
             <ReactTable
                 data={instructors}
                 columns={columns}
                 showPagination={false}
+                defaultPageSize={pageSize}
                 minRows={1}
             />
         </React.Fragment>

--- a/frontend/src/components/positions-list.js
+++ b/frontend/src/components/positions-list.js
@@ -78,11 +78,13 @@ export function PositionsDiffList({ modifiedPositions }) {
  */
 export function PositionsList(props) {
     const { positions, columns = DEFAULT_COLUMNS } = props;
+    const pageSize = positions?.length || 20;
     return (
         <ReactTable
             data={positions}
             columns={columns}
             showPagination={false}
+            defaultPageSize={pageSize}
             minRows={1}
         />
     );

--- a/frontend/src/components/sessions.js
+++ b/frontend/src/components/sessions.js
@@ -31,11 +31,13 @@ const DEFAULT_COLUMNS = [
  */
 export function SessionsList(props) {
     const { sessions, columns = DEFAULT_COLUMNS } = props;
+    const pageSize = sessions?.length || 20;
     return (
         <ReactTable
             data={sessions}
             columns={columns}
             showPagination={false}
+            defaultPageSize={pageSize}
             minRows={1}
         />
     );

--- a/frontend/src/views/applicants/import-export.tsx
+++ b/frontend/src/views/applicants/import-export.tsx
@@ -202,8 +202,9 @@ export function ConnectedImportInstructorAction() {
                     {newItems.length > 0 && (
                         <Alert variant="primary">
                             <span className="mb-1">
-                                The following applicants will be{" "}
-                                <strong>added</strong>
+                                The following <strong>{newItems.length}</strong>{" "}
+                                applicant{newItems.length > 1 ? "s" : ""} will
+                                be <strong>added</strong>
                             </span>
                             <ApplicantsList applicants={newItems} />
                         </Alert>


### PR DESCRIPTION
This PR fixes #415 
Now react tables display exactly the number of rows of data without any pagination.