### PR TITLE
[frontend] implement tests for updating offer when emailed

### DIFF
--- a/frontend/src/tests/offer-tests.js
+++ b/frontend/src/tests/offer-tests.js
@@ -78,7 +78,7 @@ export function offersTests(api) {
         let previousDate = newOffer.emailed_date;
 
         // sleep for 1s to create time diff
-        await new Promise(r => setTimeout(r, 1000));
+        await new Promise((r) => setTimeout(r, 2000));
         const resp = await apiPOST(
             `/admin/assignments/${assignment.id}/active_offer/email`
         );

--- a/frontend/src/tests/offer-tests.js
+++ b/frontend/src/tests/offer-tests.js
@@ -74,7 +74,7 @@ export function offersTests(api) {
         expect(newOffer.emailed_date).not.toBeNull();
     });
 
-    it("email the active offer again", async () => {
+    it("when an offer is emailed a second time, the emailed date is updated to the most recent emailed date", async () => {
         // record previous emailed_date
         const resp = await apiGET(
             `/admin/assignments/${assignment.id}/active_offer`

--- a/frontend/src/tests/offer-tests.js
+++ b/frontend/src/tests/offer-tests.js
@@ -75,26 +75,28 @@ export function offersTests(api) {
     });
 
     it("email the active offer again", async () => {
-        let previousDate = newOffer.emailed_date;
-
-        // sleep for 1s to create time diff
-        await new Promise((r) => setTimeout(r, 2000));
-        const resp = await apiPOST(
-            `/admin/assignments/${assignment.id}/active_offer/email`
+        // record previoud emailed_date
+        const resp = await apiGET(
+            `/admin/assignments/${assignment.id}/active_offer`
         );
         expect(resp).toHaveStatus("success");
+        let previousDate = resp.payload.emailed_date;
 
+        // send the email again
+        const resp1 = await apiPOST(
+            `/admin/assignments/${assignment.id}/active_offer/email`
+        );
+        expect(resp1).toHaveStatus("success");
         // check if date is updated
-        // eslint-disable-next-line require-atomic-updates
-        newOffer = resp.payload;
+        newOffer = resp1.payload;
         expect(newOffer.emailed_date).not.toEqual(previousDate);
 
         // check if date is updated correctly
-        const resp1 = await apiGET(
+        const resp2 = await apiGET(
             `/admin/assignments/${assignment.id}/active_offer`
         );
-        expect(resp1).toHaveStatus("success");
-        expect(resp1.payload.emailed_date).toEqual(newOffer.emailed_date);
+        expect(resp2).toHaveStatus("success");
+        expect(resp2.payload.emailed_date).toEqual(newOffer.emailed_date);
     });
 
     it("increment nag count correctly", async () => {

--- a/frontend/src/tests/offer-tests.js
+++ b/frontend/src/tests/offer-tests.js
@@ -75,7 +75,7 @@ export function offersTests(api) {
     });
 
     it("email the active offer again", async () => {
-        // record previoud emailed_date
+        // record previous emailed_date
         const resp = await apiGET(
             `/admin/assignments/${assignment.id}/active_offer`
         );

--- a/frontend/src/tests/offer-tests.js
+++ b/frontend/src/tests/offer-tests.js
@@ -74,9 +74,28 @@ export function offersTests(api) {
         expect(newOffer.emailed_date).not.toBeNull();
     });
 
-    it.todo(
-        "when an offer is emailed a second time, the emailed date is updated to the most recent emailed date"
-    );
+    it("email the active offer again", async () => {
+        let previousDate = newOffer.emailed_date;
+
+        // sleep for 1s to create time diff
+        await new Promise(r => setTimeout(r, 1000));
+        const resp = await apiPOST(
+            `/admin/assignments/${assignment.id}/active_offer/email`
+        );
+        expect(resp).toHaveStatus("success");
+
+        // check if date is updated
+        // eslint-disable-next-line require-atomic-updates
+        newOffer = resp.payload;
+        expect(newOffer.emailed_date).not.toEqual(previousDate);
+
+        // check if date is updated correctly
+        const resp1 = await apiGET(
+            `/admin/assignments/${assignment.id}/active_offer`
+        );
+        expect(resp1).toHaveStatus("success");
+        expect(resp1.payload.emailed_date).toEqual(newOffer.emailed_date);
+    });
 
     it("increment nag count correctly", async () => {
         // before nagging, make sure the status of the offer is pending

--- a/frontend/src/tests/offer-tests.js
+++ b/frontend/src/tests/offer-tests.js
@@ -80,23 +80,26 @@ export function offersTests(api) {
             `/admin/assignments/${assignment.id}/active_offer`
         );
         expect(resp).toHaveStatus("success");
-        let previousDate = resp.payload.emailed_date;
+        const previousDate = resp.payload.emailed_date;
 
         // send the email again
         const resp1 = await apiPOST(
             `/admin/assignments/${assignment.id}/active_offer/email`
         );
         expect(resp1).toHaveStatus("success");
-        // check if date is updated
+        // update newOffer
         newOffer = resp1.payload;
-        expect(newOffer.emailed_date).not.toEqual(previousDate);
+        // check if date is updated
+        const newDate = resp1.payload.emailed_date;
+        expect(Date.parse(newDate)).toBeGreaterThan(Date.parse(previousDate));
 
         // check if date is updated correctly
         const resp2 = await apiGET(
             `/admin/assignments/${assignment.id}/active_offer`
         );
         expect(resp2).toHaveStatus("success");
-        expect(resp2.payload.emailed_date).toEqual(newOffer.emailed_date);
+        const updatedDate = resp2.payload.emailed_date;
+        expect(updatedDate).toEqual(newDate);
     });
 
     it("increment nag count correctly", async () => {


### PR DESCRIPTION
Fix #476:
implement tests for:
update the emailed_date field of the assignment when the assignment is re-sent