### PR TITLE
[Frontend] Remove withdrawn/rejected assignment from add-ddah dialog dropdown

### DIFF
--- a/frontend/src/views/ddahs/add-ddah-dialog.tsx
+++ b/frontend/src/views/ddahs/add-ddah-dialog.tsx
@@ -71,6 +71,7 @@ export function ConnectedAddDdahDialog(props: {
     const assignmentsWithoutDdah = useSelector<any, Assignment[]>(
         assignmentsSelector
     ).filter((x) => {
+        // Filter assignments without ddah and status is not withdrawn or rejected
         return (
             !assignmentsWithDdahHash[x.id] &&
             x.active_offer_status !== "withdrawn" &&

--- a/frontend/src/views/ddahs/add-ddah-dialog.tsx
+++ b/frontend/src/views/ddahs/add-ddah-dialog.tsx
@@ -73,11 +73,10 @@ export function ConnectedAddDdahDialog(props: {
     ).filter((x) => {
         return (
             !assignmentsWithDdahHash[x.id] &&
-            (x.active_offer_status !== "withdrawn" &&
-                x.active_offer_status !== "rejected")
+            x.active_offer_status !== "withdrawn" &&
+            x.active_offer_status !== "rejected"
         );
     });
-
 
     function _upsertDdah(ddah: PartialDdah) {
         if (ddah.assignment == null) {

--- a/frontend/src/views/ddahs/add-ddah-dialog.tsx
+++ b/frontend/src/views/ddahs/add-ddah-dialog.tsx
@@ -70,7 +70,13 @@ export function ConnectedAddDdahDialog(props: {
     }
     const assignmentsWithoutDdah = useSelector<any, Assignment[]>(
         assignmentsSelector
-    ).filter((x) => !assignmentsWithDdahHash[x.id]);
+    ).filter((x) => {
+        return (
+            !assignmentsWithDdahHash[x.id] &&
+            (x.active_offer_status === "pending" ||
+                x.active_offer_status === "accepted")
+        );
+    });
 
     function _upsertDdah(ddah: PartialDdah) {
         if (ddah.assignment == null) {

--- a/frontend/src/views/ddahs/add-ddah-dialog.tsx
+++ b/frontend/src/views/ddahs/add-ddah-dialog.tsx
@@ -73,10 +73,11 @@ export function ConnectedAddDdahDialog(props: {
     ).filter((x) => {
         return (
             !assignmentsWithDdahHash[x.id] &&
-            (x.active_offer_status === "pending" ||
-                x.active_offer_status === "accepted")
+            (x.active_offer_status !== "withdrawn" &&
+                x.active_offer_status !== "rejected")
         );
     });
+
 
     function _upsertDdah(ddah: PartialDdah) {
         if (ddah.assignment == null) {


### PR DESCRIPTION
Added filter conditions so that assignments with withdrawn/rejected offer status are not shown in the add-ddah dialog dropdown. fixes #475 