### PR TITLE
Implement reporting tag tests

### DIFF
--- a/frontend/src/tests/api.test.js
+++ b/frontend/src/tests/api.test.js
@@ -68,7 +68,7 @@ describe("API tests", () => {
             offerDownloadTests({ apiGET, apiPOST });
         });
     });
-    describe.skip("reporting_tag tests", () => {
+    describe("reporting_tag tests", () => {
         reportingTagsTests({ apiGET, apiPOST });
     });
     describe.skip("`/admin/applications` tests", () => {

--- a/frontend/src/tests/reporting-tag-tests.js
+++ b/frontend/src/tests/reporting-tag-tests.js
@@ -146,7 +146,32 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
         };
 
         const resp = await apiGET(
-            `/admin/positions/${position.id}/reporting_tags`
+            `/admin/wage_chunks/${wage_chunk.id}/reporting_tags`
+        );
+
+        expect(resp).toHaveStatus("success");
+        expect(resp.payload).not.toContainObject(reporting_tag);
+
+        const resp1 = await apiPOST(
+            `/admin/wage_chunks/${wage_chunk.id}/reporting_tags`,
+            reporting_tag
+        );
+
+        const resp2 = await apiGET(
+            `/admin/wage_chunks/${wage_chunk.id}/reporting_tags`
+        );
+
+        expect(resp2).toHaveStatus("success");
+        expect(resp2.payload).toContainObject(reporting_tag);
+    });
+
+    it("get all reporting_tags associated to position for session", async () => {
+        let reporting_tag = {
+            name: "The Bigger Cheese in the session",
+        };
+
+        const resp = await apiGET(
+            `/admin/sessions/${session.id}/positions/reporting_tags`
         );
 
         expect(resp).toHaveStatus("success");
@@ -158,13 +183,35 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
         );
 
         const resp2 = await apiGET(
-            `/admin/positions/${position.id}/reporting_tags`
+            `/admin/sessions/${session.id}/positions/reporting_tags`
         );
 
         expect(resp2).toHaveStatus("success");
         expect(resp2.payload).toContainObject(reporting_tag);
     });
 
-    it.todo("get all reporting_tags associated to positions for session");
-    it.todo("get all reporting_tags associated to wage_chunks for session");
+    it("get all reporting_tags associated to wage_chunks for session", async () => {
+        let reporting_tag = {
+            name: "The wage of the Bigger Cheese in the session",
+        };
+
+        const resp = await apiGET(
+            `/admin/sessions/${session.id}/wage_chunks/reporting_tags`
+        );
+
+        expect(resp).toHaveStatus("success");
+        expect(resp.payload).not.toContainObject(reporting_tag);
+
+        const resp1 = await apiPOST(
+            `/admin/wage_chunk/${wage_chunk.id}/reporting_tags`,
+            reporting_tag
+        );
+
+        const resp2 = await apiGET(
+            `/admin/sessions/${session.id}/wage_chunks/reporting_tags`
+        );
+
+        expect(resp2).toHaveStatus("success");
+        expect(resp2.payload).toContainObject(reporting_tag);
+    });
 }

--- a/frontend/src/tests/reporting-tag-tests.js
+++ b/frontend/src/tests/reporting-tag-tests.js
@@ -1,12 +1,134 @@
-import { it } from "./utils";
+import PropTypes from "prop-types";
+import {
+    checkPropTypes,
+    positionPropTypes,
+    errorPropTypes,
+    expect,
+    it,
+    beforeAll,
+    apiGET,
+    apiPOST,
+    reportingTagsPropTypes,
+} from "./utils";
+
+import { databaseSeeder } from "./setup";
 
 // TODO: Remove eslint disable. This can be done as soon as these tests are actually implemented.
 // eslint-disable-next-line
-export function reportingTagsTests({ apiGET, apiPOST }) {
+export function reportingTagsTests(api = { apiGET, apiPOST }) {
+    const { apiGET, apiPOST } = api;
+    const session = databaseSeeder.seededData.session,
+        contractTemplate = databaseSeeder.seededData.contractTemplate,
+        assignment = databaseSeeder.seededData.assignment,
+        position = databaseSeeder.seededData.position;
+
+    let wage_chunk;
+
+    beforeAll(async () => {
+        await databaseSeeder.seed(api);
+
+        // Get wageChunks
+        const resp = await apiGET(
+            `/admin/assignments/${assignment.id}/wage_chunks`
+        );
+        expect(resp).toHaveStatus("success");
+    });
+
+    it("create reporting_tags for position", async () => {
+        const reporting_tag = {
+            name: "The Big Cheese",
+        };
+
+        const resp1 = await apiPOST(
+            `/admin/positions/${position.id}/reporting_tags`,
+            reporting_tag
+        );
+
+        expect(resp1).toHaveStatus("success");
+        expect(resp1.payload).toContainObject(reporting_tag);
+    });
+
+    it("delete reporting_tags for position", async () => {
+        const reporting_tag = {
+            name: "The Big Bad Cheese",
+        };
+
+        const resp1 = await apiPOST(
+            `/admin/positions/${position.id}/reporting_tags`,
+            reporting_tag
+        );
+        expect(resp1).toHaveStatus("success");
+
+        const resp2 = await apiPOST(
+            `/admin//positions/${position.id}/reporting_tags/delete`,
+            reporting_tag
+        );
+        expect(resp2).toHaveStatus("success");
+        expect(resp2.payload).toContainObject(reporting_tag);
+
+        const resp3 = await apiGET(
+            `/admin//positions/${position.id}/reporting_tags`
+        );
+
+        expect(resp3).toHaveStatus("success");
+        expect(resp3.payload).not.toContainObject(reporting_tag);
+    });
+
+    it("get reporting_tags for position", async () => {
+        let reporting_tag = {
+            name: "The Bigger Cheese",
+        };
+
+        const resp = await apiGET(
+            `/admin//positions/${position.id}/reporting_tags`
+        );
+
+        expect(resp).toHaveStatus("success");
+        expect(resp.payload).not.toContainObject(reporting_tag);
+
+        const resp1 = await apiPOST(
+            `/admin/positions/${position.id}/reporting_tags`,
+            reporting_tag
+        );
+
+        const resp2 = await apiGET(
+            `/admin//positions/${position.id}/reporting_tags`
+        );
+
+        expect(resp2).toHaveStatus("success");
+        expect(resp2.payload).toContainObject(reporting_tag);
+    });
+
+    // it("create and delete reporting_tags for wage_chunk", async () => {
+    //     let reporting_tag = {
+    //         name: "The Big Cheese",
+    //     };
+
+    //     const resp1 = await apiPOST(
+    //         `/admin/positions/${position.id}/reporting_tags`,
+    //         reporting_tag
+    //     );
+
+    //     expect(resp1).toHaveStatus("success");
+
+    //     // make sure the reporting tag we created is in that list and has the correct props
+    //     expect(resp1.payload).toContain(reporting_tag);
+
+    //     const resp2 = await apiPOST(
+    //         `/admin//positions/${position.id}/reporting_tags/delete`
+    //     );
+
+    //     expect(resp2).toHaveStatus("success");
+
+    //     const resp3 = await apiGET(
+    //         `/admin//positions/${position.id}/reporting_tags`
+    //     );
+
+    //     expect(resp3).toHaveStatus("success");
+    //     expect(resp3.payload).toContainObject([]);
+    // });
+
     it.todo("get all reporting_tags associated to positions for session");
     it.todo("get all reporting_tags associated to wage_chunks for session");
-    it.todo("get reporting_tags for position");
     it.todo("get reporting_tags for wage_chunk");
-    it.todo("create and delete reporting_tags for position");
-    it.todo("create and delete reporting_tags for wage_chunk");
 }

--- a/frontend/src/tests/reporting-tag-tests.js
+++ b/frontend/src/tests/reporting-tag-tests.js
@@ -206,7 +206,7 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
             `/admin/wage_chunks/${wage_chunk.id}/reporting_tags`,
             reporting_tag
         );
-        
+
         const resp2 = await apiGET(
             `/admin/sessions/${session.id}/wage_chunks/reporting_tags`
         );

--- a/frontend/src/tests/reporting-tag-tests.js
+++ b/frontend/src/tests/reporting-tag-tests.js
@@ -18,7 +18,6 @@ import { databaseSeeder } from "./setup";
 export function reportingTagsTests(api = { apiGET, apiPOST }) {
     const { apiGET, apiPOST } = api;
     const session = databaseSeeder.seededData.session,
-        contractTemplate = databaseSeeder.seededData.contractTemplate,
         assignment = databaseSeeder.seededData.assignment,
         position = databaseSeeder.seededData.position;
 

--- a/frontend/src/tests/reporting-tag-tests.js
+++ b/frontend/src/tests/reporting-tag-tests.js
@@ -46,12 +46,12 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
         );
 
         expect(resp1).toHaveStatus("success");
-        expect(resp1.payload).toContainObject(reporting_tag);
+        expect(resp1.payload).toMatchObject(reporting_tag);
     });
 
     it("delete reporting_tags for position", async () => {
         const reporting_tag = {
-            name: "The Big Bad Cheese",
+            name: "Test reporting tag position delete",
         };
 
         const resp1 = await apiPOST(
@@ -65,14 +65,14 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
             reporting_tag
         );
         expect(resp2).toHaveStatus("success");
-        expect(resp2.payload).toContainObject(reporting_tag);
+        expect(resp2.payload).toMatchObject(reporting_tag);
 
         const resp3 = await apiGET(
             `/admin/positions/${position.id}/reporting_tags`
         );
 
         expect(resp3).toHaveStatus("success");
-        expect(resp3.payload).not.toContainObject(reporting_tag);
+        expect(resp3.payload).not.toMatchObject(reporting_tag);
     });
 
     it("get reporting_tags for position", async () => {
@@ -102,7 +102,7 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
 
     it("create reporting_tags for wage_chunk", async () => {
         let reporting_tag = {
-            name: "The wage for the Big Cheese",
+            name: "Test Reporting Tag Wage Chunk Creation",
         };
 
         const resp1 = await apiPOST(
@@ -111,12 +111,12 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
         );
 
         expect(resp1).toHaveStatus("success");
-        expect(resp1.payload).toContain(reporting_tag);
+        expect(resp1.payload).toMatchObject(reporting_tag);
     });
 
     it("delete reporting_tags for wage_chunk", async () => {
         const reporting_tag = {
-            name: "The Wage for the Big Bad Cheese",
+            name: "Test Reporting Wage Chunk Deletion",
         };
 
         const resp1 = await apiPOST(
@@ -130,14 +130,14 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
             reporting_tag
         );
         expect(resp2).toHaveStatus("success");
-        expect(resp2.payload).toContainObject(reporting_tag);
+        expect(resp2.payload).toMatchObject(reporting_tag);
 
         const resp3 = await apiGET(
             `/admin/wage_chunks/${wage_chunk.id}/reporting_tags`
         );
 
         expect(resp3).toHaveStatus("success");
-        expect(resp3.payload).not.toContainObject(reporting_tag);
+        expect(resp3.payload).not.toMatchObject(reporting_tag);
     });
 
     it("get reporting_tags for wage_chunk", async () => {
@@ -203,10 +203,10 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
         expect(resp.payload).not.toContainObject(reporting_tag);
 
         const resp1 = await apiPOST(
-            `/admin/wage_chunk/${wage_chunk.id}/reporting_tags`,
+            `/admin/wage_chunks/${wage_chunk.id}/reporting_tags`,
             reporting_tag
         );
-
+        
         const resp2 = await apiGET(
             `/admin/sessions/${session.id}/wage_chunks/reporting_tags`
         );

--- a/frontend/src/tests/reporting-tag-tests.js
+++ b/frontend/src/tests/reporting-tag-tests.js
@@ -37,7 +37,7 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
 
     it("create reporting_tags for position", async () => {
         const reporting_tag = {
-            name: "The Big Cheese",
+            name: "Test reporting tag for position creation",
         };
 
         const resp1 = await apiPOST(
@@ -77,7 +77,7 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
 
     it("get reporting_tags for position", async () => {
         let reporting_tag = {
-            name: "The Bigger Cheese",
+            name: "Test reporting tag for position fetch",
         };
 
         const resp = await apiGET(
@@ -102,7 +102,7 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
 
     it("create reporting_tags for wage_chunk", async () => {
         let reporting_tag = {
-            name: "Test Reporting Tag Wage Chunk Creation",
+            name: "Test reporting tag wage chunk creation",
         };
 
         const resp1 = await apiPOST(
@@ -116,7 +116,7 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
 
     it("delete reporting_tags for wage_chunk", async () => {
         const reporting_tag = {
-            name: "Test Reporting Wage Chunk Deletion",
+            name: "Test reporting wage chunk deletion",
         };
 
         const resp1 = await apiPOST(
@@ -142,7 +142,7 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
 
     it("get reporting_tags for wage_chunk", async () => {
         let reporting_tag = {
-            name: "The Wage for the Bigger Cheese",
+            name: "Test reporting tag for wage_chunk fetch",
         };
 
         const resp = await apiGET(
@@ -167,7 +167,7 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
 
     it("get all reporting_tags associated to position for session", async () => {
         let reporting_tag = {
-            name: "The Bigger Cheese in the session",
+            name: "Test reporting tag for position fetch in session",
         };
 
         const resp = await apiGET(
@@ -192,7 +192,7 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
 
     it("get all reporting_tags associated to wage_chunks for session", async () => {
         let reporting_tag = {
-            name: "The wage of the Bigger Cheese in the session",
+            name: "Test reporting tag for wage_chunk fetch in session",
         };
 
         const resp = await apiGET(

--- a/frontend/src/tests/reporting-tag-tests.js
+++ b/frontend/src/tests/reporting-tag-tests.js
@@ -1,16 +1,4 @@
-import PropTypes from "prop-types";
-import {
-    checkPropTypes,
-    positionPropTypes,
-    errorPropTypes,
-    expect,
-    it,
-    beforeAll,
-    apiGET,
-    apiPOST,
-    reportingTagsPropTypes,
-} from "./utils";
-
+import { expect, it, beforeAll, apiGET, apiPOST } from "./utils";
 import { databaseSeeder } from "./setup";
 
 // TODO: Remove eslint disable. This can be done as soon as these tests are actually implemented.
@@ -86,7 +74,7 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
         expect(resp).toHaveStatus("success");
         expect(resp.payload).not.toContainObject(reporting_tag);
 
-        const resp1 = await apiPOST(
+        await apiPOST(
             `/admin/positions/${position.id}/reporting_tags`,
             reporting_tag
         );
@@ -118,11 +106,10 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
             name: "Test reporting wage chunk deletion",
         };
 
-        const resp1 = await apiPOST(
+        await apiPOST(
             `/admin/wage_chunks/${wage_chunk.id}/reporting_tags`,
             reporting_tag
         );
-        expect(resp1).toHaveStatus("success");
 
         const resp2 = await apiPOST(
             `/admin/wage_chunks/${wage_chunk.id}/reporting_tags/delete`,
@@ -151,7 +138,7 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
         expect(resp).toHaveStatus("success");
         expect(resp.payload).not.toContainObject(reporting_tag);
 
-        const resp1 = await apiPOST(
+        await apiPOST(
             `/admin/wage_chunks/${wage_chunk.id}/reporting_tags`,
             reporting_tag
         );
@@ -176,7 +163,7 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
         expect(resp).toHaveStatus("success");
         expect(resp.payload).not.toContainObject(reporting_tag);
 
-        const resp1 = await apiPOST(
+        await apiPOST(
             `/admin/positions/${position.id}/reporting_tags`,
             reporting_tag
         );
@@ -199,9 +186,8 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
         );
 
         expect(resp).toHaveStatus("success");
-        expect(resp.payload).not.toContainObject(reporting_tag);
 
-        const resp1 = await apiPOST(
+        await apiPOST(
             `/admin/wage_chunks/${wage_chunk.id}/reporting_tags`,
             reporting_tag
         );

--- a/frontend/src/tests/reporting-tag-tests.js
+++ b/frontend/src/tests/reporting-tag-tests.js
@@ -31,7 +31,8 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
         const resp = await apiGET(
             `/admin/assignments/${assignment.id}/wage_chunks`
         );
-        expect(resp).toHaveStatus("success");
+
+        wage_chunk = resp.payload[0];
     });
 
     it("create reporting_tags for position", async () => {
@@ -60,14 +61,14 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
         expect(resp1).toHaveStatus("success");
 
         const resp2 = await apiPOST(
-            `/admin//positions/${position.id}/reporting_tags/delete`,
+            `/admin/positions/${position.id}/reporting_tags/delete`,
             reporting_tag
         );
         expect(resp2).toHaveStatus("success");
         expect(resp2.payload).toContainObject(reporting_tag);
 
         const resp3 = await apiGET(
-            `/admin//positions/${position.id}/reporting_tags`
+            `/admin/positions/${position.id}/reporting_tags`
         );
 
         expect(resp3).toHaveStatus("success");
@@ -80,7 +81,7 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
         };
 
         const resp = await apiGET(
-            `/admin//positions/${position.id}/reporting_tags`
+            `/admin/positions/${position.id}/reporting_tags`
         );
 
         expect(resp).toHaveStatus("success");
@@ -92,43 +93,78 @@ export function reportingTagsTests(api = { apiGET, apiPOST }) {
         );
 
         const resp2 = await apiGET(
-            `/admin//positions/${position.id}/reporting_tags`
+            `/admin/positions/${position.id}/reporting_tags`
         );
 
         expect(resp2).toHaveStatus("success");
         expect(resp2.payload).toContainObject(reporting_tag);
     });
 
-    // it("create and delete reporting_tags for wage_chunk", async () => {
-    //     let reporting_tag = {
-    //         name: "The Big Cheese",
-    //     };
+    it("create reporting_tags for wage_chunk", async () => {
+        let reporting_tag = {
+            name: "The wage for the Big Cheese",
+        };
 
-    //     const resp1 = await apiPOST(
-    //         `/admin/positions/${position.id}/reporting_tags`,
-    //         reporting_tag
-    //     );
+        const resp1 = await apiPOST(
+            `/admin/wage_chunks/${wage_chunk.id}/reporting_tags`,
+            reporting_tag
+        );
 
-    //     expect(resp1).toHaveStatus("success");
+        expect(resp1).toHaveStatus("success");
+        expect(resp1.payload).toContain(reporting_tag);
+    });
 
-    //     // make sure the reporting tag we created is in that list and has the correct props
-    //     expect(resp1.payload).toContain(reporting_tag);
+    it("delete reporting_tags for wage_chunk", async () => {
+        const reporting_tag = {
+            name: "The Wage for the Big Bad Cheese",
+        };
 
-    //     const resp2 = await apiPOST(
-    //         `/admin//positions/${position.id}/reporting_tags/delete`
-    //     );
+        const resp1 = await apiPOST(
+            `/admin/wage_chunks/${wage_chunk.id}/reporting_tags`,
+            reporting_tag
+        );
+        expect(resp1).toHaveStatus("success");
 
-    //     expect(resp2).toHaveStatus("success");
+        const resp2 = await apiPOST(
+            `/admin/wage_chunks/${wage_chunk.id}/reporting_tags/delete`,
+            reporting_tag
+        );
+        expect(resp2).toHaveStatus("success");
+        expect(resp2.payload).toContainObject(reporting_tag);
 
-    //     const resp3 = await apiGET(
-    //         `/admin//positions/${position.id}/reporting_tags`
-    //     );
+        const resp3 = await apiGET(
+            `/admin/wage_chunks/${wage_chunk.id}/reporting_tags`
+        );
 
-    //     expect(resp3).toHaveStatus("success");
-    //     expect(resp3.payload).toContainObject([]);
-    // });
+        expect(resp3).toHaveStatus("success");
+        expect(resp3.payload).not.toContainObject(reporting_tag);
+    });
+
+    it("get reporting_tags for wage_chunk", async () => {
+        let reporting_tag = {
+            name: "The Wage for the Bigger Cheese",
+        };
+
+        const resp = await apiGET(
+            `/admin/positions/${position.id}/reporting_tags`
+        );
+
+        expect(resp).toHaveStatus("success");
+        expect(resp.payload).not.toContainObject(reporting_tag);
+
+        const resp1 = await apiPOST(
+            `/admin/positions/${position.id}/reporting_tags`,
+            reporting_tag
+        );
+
+        const resp2 = await apiGET(
+            `/admin/positions/${position.id}/reporting_tags`
+        );
+
+        expect(resp2).toHaveStatus("success");
+        expect(resp2.payload).toContainObject(reporting_tag);
+    });
 
     it.todo("get all reporting_tags associated to positions for session");
     it.todo("get all reporting_tags associated to wage_chunks for session");
-    it.todo("get reporting_tags for wage_chunk");
 }


### PR DESCRIPTION
As the title says. Implement tests for fetching, creating, and deleting reporting tags for positions and wage_chunks. Tests also cover fetches in sessions.