### PR TITLE
Fix skipped posting tests

### DIFF
--- a/backend/app/controllers/api/v1/admin/posting_positions_controller.rb
+++ b/backend/app/controllers/api/v1/admin/posting_positions_controller.rb
@@ -24,6 +24,21 @@ class Api::V1::Admin::PostingPositionsController < ApplicationController
     def create
         find_posting
         find_posting_position
+
+        # If @posting_position is non-nil, it is most likely from the same session.
+        # If it is nil, either it is brand new, or it doesn't belong to the current session.
+        # Either way, we look up the position to check that it belongs to the same session as the posting
+        position =
+            if @posting_position.nil?
+                Position.find_by(id: params[:position_id])
+            else
+                @posting_position.position
+            end
+        if !position.nil? && position.session_id != @posting.session_id
+            raise StandardError,
+                  'Cannot create a posting_position for a position and posting that belong to different sessions'
+        end
+
         upsert
         render_success @posting_position
     end

--- a/backend/app/models/posting.rb
+++ b/backend/app/models/posting.rb
@@ -3,8 +3,8 @@
 class Posting < ApplicationRecord
     POSTING_AVAILABILITY = %i[auto closed open].freeze
     belongs_to :session
-    has_many :posting_positions
-    has_many :applications
+    has_many :posting_positions, dependent: :destroy
+    has_many :applications, dependent: :destroy
 
     has_secure_token :url_token
     enum availability: POSTING_AVAILABILITY

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -59,7 +59,7 @@ module Tapp
         email_port = ENV.fetch('EMAIL_PORT', 25).presence || 25
         config.action_mailer.raise_delivery_errors = true
         config.action_mailer.default_url_options = {
-            host: '${confit.base_url}'
+            host: config.base_url
         }
         config.action_mailer.perform_caching = true
         config.action_mailer.delivery_method = :smtp

--- a/frontend/src/tests/api.test.js
+++ b/frontend/src/tests/api.test.js
@@ -79,7 +79,7 @@ describe("API tests", () => {
     describe("reporting_tag tests", () => {
         reportingTagsTests({ apiGET, apiPOST });
     });
-    describe.skip("`/admin/applications` tests", () => {
+    describe("`/admin/applications` tests", () => {
         applicationsTests({ apiGET, apiPOST });
     });
     describe("unknown api route tests", () => {

--- a/frontend/src/tests/posting-tests.js
+++ b/frontend/src/tests/posting-tests.js
@@ -273,7 +273,7 @@ export function postingTests(api) {
         });
     });
 
-    it.skip("Cannot create a posting_position with a position associated with a different session than the posting", async () => {
+    it("Cannot create a posting_position with a position associated with a different session than the posting", async () => {
         const newPosting = {
             name: "CSC500F TA",
             intro_text: "Posting for CSC500F",
@@ -368,7 +368,7 @@ export function postingTests(api) {
         ).toBeUndefined();
     });
 
-    it.skip("Deleting a posting also deletes all associated posting_positions", async () => {
+    it("Deleting a posting also deletes all associated posting_positions", async () => {
         // Recreate the posting_position because it has been deleted in the previous test case
         resp = await apiPOST(
             `/admin/postings/${posting.id}/posting_positions`,


### PR DESCRIPTION
Two postings tests were skipped because of errors in the backend. The errors are fixed and the tests are enabled.