### PR TITLE
Add a /hash proxy route to preserve the route hash during shibboleth authentication

### DIFF
--- a/backend/app/controllers/hash/hash_controller.rb
+++ b/backend/app/controllers/hash/hash_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class Hash::HashController < ApplicationController
+    before_action :find_hash
+
+    # /hash/*path
+    # This function redirects urls from `/hash/*path` to `/#/*path`. It is needed
+    # to preserve redirection functionality via shibboleth. URL hashes are used
+    # in the frontend for routing. However, since URL hashes are not passed to the server, 
+    # they are lost. By changing the URL hash to an actual URL, we are able to preserve it
+    # during authentication.
+    def index
+        # take special care to preserve the raw query string rather than process it
+        # through rails params.
+        query_string = request.query_string
+        redirect_url =
+            query_string.blank? ? "/##{@hash}" : "/?#{query_string}##{@hash}"
+        render(
+            plain:
+                "<!doctype html><html>
+                <head>
+                    <meta charset=\"utf-8\">
+                    <meta http-equiv=\"refresh\" content=\"0; URL='#{
+                    redirect_url
+                }'\"
+                </head>
+                <body>Redirecting to 
+                    <a href=\"#{redirect_url}\">#{redirect_url}</a>
+                </body></html>",
+            content_type: 'text/html'
+        )
+    end
+
+    private
+
+    def find_hash
+        raw_hash = params['path']
+        # we want the first character of the hash to always be `/`
+        raw_hash = raw_hash.sub(%r{^([^\/])}, '/\1')
+        @hash = raw_hash
+    end
+end

--- a/backend/app/controllers/hash/hash_controller.rb
+++ b/backend/app/controllers/hash/hash_controller.rb
@@ -6,7 +6,7 @@ class Hash::HashController < ApplicationController
     # /hash/*path
     # This function redirects urls from `/hash/*path` to `/#/*path`. It is needed
     # to preserve redirection functionality via shibboleth. URL hashes are used
-    # in the frontend for routing. However, since URL hashes are not passed to the server, 
+    # in the frontend for routing. However, since URL hashes are not passed to the server,
     # they are lost. By changing the URL hash to an actual URL, we are able to preserve it
     # during authentication.
     def index
@@ -24,7 +24,7 @@ class Hash::HashController < ApplicationController
                     redirect_url
                 }'\"
                 </head>
-                <body>Redirecting to 
+                <body>Redirecting to
                     <a href=\"#{redirect_url}\">#{redirect_url}</a>
                 </body></html>",
             content_type: 'text/html'
@@ -36,7 +36,7 @@ class Hash::HashController < ApplicationController
     def find_hash
         raw_hash = params['path']
         # we want the first character of the hash to always be `/`
-        raw_hash = raw_hash.sub(%r{^([^\/])}, '/\1')
+        raw_hash = raw_hash.sub(%r{^([^/])}, '/\1')
         @hash = raw_hash
     end
 end

--- a/backend/app/mailers/ddah_mailer.rb
+++ b/backend/app/mailers/ddah_mailer.rb
@@ -49,8 +49,10 @@ class DdahMailer < ActionMailer::Base
         @position_title = ddah.assignment.position.position_title
         @ta_coordinator_email = Rails.application.config.ta_coordinator_email
         # TODO:  This seems too hard-coded.  Is there another way to get the route?
+        # Note, we are using the `/hash` route proxying (instead of `#` hash) to avoid issues with Shibboleth authentication
+        # See details in routes.rb
         @url =
-            "#{Rails.application.config.base_url}/#/public/ddahs/#{
+            "#{Rails.application.config.base_url}/hash/public/ddahs/#{
                 ddah.url_token
             }"
 

--- a/backend/app/mailers/ddah_mailer.rb
+++ b/backend/app/mailers/ddah_mailer.rb
@@ -23,9 +23,7 @@ class DdahMailer < ActionMailer::Base
                 # by calling format.html/format.text we can use our own templates
                 # in place of the rails erd's.
                 format.html { render inline: html }
-                format.text do
-                    render plain: HtmlToPlainText.plain_text(html)
-                end
+                format.text { render plain: HtmlToPlainText.plain_text(html) }
             end
         rescue Net::SMTPFatalError => e
             raise StandardError, "Error when #{debug_message} (#{e})"
@@ -49,7 +47,8 @@ class DdahMailer < ActionMailer::Base
         @position_title = ddah.assignment.position.position_title
         @ta_coordinator_email = Rails.application.config.ta_coordinator_email
         # TODO:  This seems too hard-coded.  Is there another way to get the route?
-        # Note, we are using the `/hash` route proxying (instead of `#` hash) to avoid issues with Shibboleth authentication
+        # Note, we are using the `/hash` route proxying (instead of `#` hash)
+        # to avoid issues with Shibboleth authentication
         # See details in routes.rb
         @url =
             "#{Rails.application.config.base_url}/hash/public/ddahs/#{

--- a/backend/app/services/active_user_service.rb
+++ b/backend/app/services/active_user_service.rb
@@ -18,7 +18,12 @@ class ActiveUserService
                 )
             utorid, _password = credentials.split(':')
             user = User.find_by(utorid: utorid) || User.new(utorid: utorid)
-            return User.new(utorid: utorid, roles: user.computed_roles)
+            return(
+                logged_user(
+                    User.new(utorid: utorid, roles: user.computed_roles),
+                    'Basic Auth'
+                )
+            )
         end
 
         if (Rails.application.config.respond_to? :active_user_override) &&
@@ -31,7 +36,13 @@ class ActiveUserService
                     User.new(
                         utorid: 'defaultactive', roles: %w[admin instructor ta]
                     )
-            return User.new(utorid: user.utorid, roles: user.computed_roles)
+
+            return(
+                logged_user(
+                    User.new(utorid: user.utorid, roles: user.computed_roles),
+                    'Debug ActiveUser Override'
+                )
+            )
         end
 
         # If we made it here, we should be using Shibboleth authentication.
@@ -40,11 +51,43 @@ class ActiveUserService
         if request.env['HTTP_X_FORWARDED_USER']
             utorid = request.env['HTTP_X_FORWARDED_USER']
             user = User.find_by(utorid: utorid) || User.new(utorid: utorid)
-            return User.new(utorid: utorid, roles: user.computed_roles)
+            return(
+                logged_user(
+                    User.new(utorid: utorid, roles: user.computed_roles),
+                    'Shibboleth'
+                )
+            )
         end
+
+        # If we made it here, none of the authentication methods applied.
+        # Print out some debug information before erroring
+        Rails
+            .logger.warn 'Failed all authentication methods. Printing request.env for debugging purposes.'
+        Rails.logger.warn request.headers.env.reject { |key|
+                              key.to_s.include?('.')
+                          }.to_json
 
         # rubocop:disable Style/RaiseArgs
         raise NotImplementedError.new 'active_user Route is not implemented for this authentication type'
         # rubocop:enable Style/RaiseArgs
     end
+end
+
+def logged_user(user, auth_type)
+    Rails.logger.warn do
+        blue_bold_start = ''
+        magenta_start = ''
+        color_end = ''
+        if Rails.env.development?
+            # Format the traceback message to be in color if we're in dev mode.
+            blue_bold_start = "\e[1;34m"
+            magenta_start = "\e[0;35m"
+            color_end = "\e[0m"
+        end
+        "#{magenta_start}Authenticated '#{blue_bold_start}#{user.utorid}#{
+            magenta_start
+        }' as #{user.roles.to_json} (auth type: #{auth_type})#{color_end}"
+    end
+
+    user
 end

--- a/backend/app/services/offer_service.rb
+++ b/backend/app/services/offer_service.rb
@@ -20,8 +20,10 @@ class OfferService
             position_title: @offer.position_title,
             ta_coordinator_email: @offer.ta_coordinator_email,
             # TODO:  This seems too hard-coded.  Is there another way to get the route?
+            # Note, we are using the `/hash` route proxying (instead of `#` hash) to avoid issues with Shibboleth authentication
+            # See details in routes.rb
             url:
-                "#{Rails.application.config.base_url}/#/public/contracts/#{
+                "#{Rails.application.config.base_url}/hash/public/contracts/#{
                     @offer.url_token
                 }",
             nag_count: @offer.nag_count,

--- a/backend/app/services/offer_service.rb
+++ b/backend/app/services/offer_service.rb
@@ -20,7 +20,8 @@ class OfferService
             position_title: @offer.position_title,
             ta_coordinator_email: @offer.ta_coordinator_email,
             # TODO:  This seems too hard-coded.  Is there another way to get the route?
-            # Note, we are using the `/hash` route proxying (instead of `#` hash) to avoid issues with Shibboleth authentication
+            # Note, we are using the `/hash` route proxying (instead of `#` hash)
+            # to avoid issues with Shibboleth authentication
             # See details in routes.rb
             url:
                 "#{Rails.application.config.base_url}/hash/public/contracts/#{

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -261,6 +261,15 @@ Rails
             resources :files, only: %i[show]
         end
 
+        # We proxy URL hashes through `/hash` so that they can be preserved during
+        # Shibboleth authentication. For example, if you try to shibboleth-authenticated
+        # `tapp.com#/my/route`, after authentication, you will be redirected to `tapp.com`,
+        # with the `#/my/route` being lost. Instead, authenticate `tapp.com/hash/my/route`,
+        # which will redirect to `tapp.com/#/my/route` after authentication is complete.
+        namespace :hash, format: false do
+            get '/*path', to: "hash#index"
+        end
+
         # Catch all other route requests and deliver a standard error payload.
         # Routes that are inaccessible due to lacking permission also end up here.
         #

--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -26,4 +26,11 @@ module.exports = function (app) {
             changeOrigin: true,
         })
     );
+    app.use(
+        "/hash",
+        createProxyMiddleware({
+            target: "http://backend:3000",
+            changeOrigin: true,
+        })
+    );
 };

--- a/frontend/src/views/admin/postings/posting-details.tsx
+++ b/frontend/src/views/admin/postings/posting-details.tsx
@@ -31,7 +31,9 @@ function PostingLinkDialog({
     onHide: Function;
 }) {
     const url = new URL(window.location.origin);
-    url.hash = `/public/postings/${posting.url_token}`;
+    // We use `pathname` instead of `hash` here to work around routing
+    // issues for pre-authenticated users.
+    url.pathname = `/hash/public/postings/${posting.url_token}`;
 
     return (
         <Modal show={visible} onHide={onHide} size="lg">


### PR DESCRIPTION
Add a /hash proxy route to preserve the route hash during shibboleth authentication