### PR TITLE
omitPrefix in apiGET and apiPOST functions

### DIFF
--- a/frontend/src/tests/utils.js
+++ b/frontend/src/tests/utils.js
@@ -175,7 +175,7 @@ function _ensurePath(path) {
  * @returns
  */
 export async function apiGET(url, omitPrefix = false) {
-    url = omitPrefix ? _ensurePath(url) : API_URL + _ensurePath(url);
+    url = omitPrefix ? API_URL + _ensurePath(url) : _ensurePath(url);
     let resp = null;
     try {
         resp = await axios.get(url);
@@ -202,7 +202,7 @@ export async function apiGET(url, omitPrefix = false) {
  * @returns
  */
 export async function apiPOST(url, body = {}, omitPrefix = false) {
-    url = omitPrefix ? _ensurePath(url) : API_URL + _ensurePath(url);
+    url = omitPrefix ? API_URL + _ensurePath(url) : _ensurePath(url);
     let resp = null;
     try {
         resp = await axios.post(url, body);

--- a/frontend/src/tests/utils.js
+++ b/frontend/src/tests/utils.js
@@ -175,7 +175,7 @@ function _ensurePath(path) {
  * @returns
  */
 export async function apiGET(url, omitPrefix = false) {
-    url = omitPrefix ? API_URL + _ensurePath(url) : _ensurePath(url);
+    url = omitPrefix ? _ensurePath(url) : API_URL + _ensurePath(url);
     let resp = null;
     try {
         resp = await axios.get(url);
@@ -202,7 +202,7 @@ export async function apiGET(url, omitPrefix = false) {
  * @returns
  */
 export async function apiPOST(url, body = {}, omitPrefix = false) {
-    url = omitPrefix ? API_URL + _ensurePath(url) : _ensurePath(url);
+    url = omitPrefix ? _ensurePath(url) : API_URL + _ensurePath(url);
     let resp = null;
     try {
         resp = await axios.post(url, body);

--- a/frontend/src/tests/utils.js
+++ b/frontend/src/tests/utils.js
@@ -174,8 +174,8 @@ function _ensurePath(path) {
  * @param {string} url The api un-prefixed url route (e.g. "/sessions")
  * @returns
  */
-export async function apiGET(url) {
-    url = API_URL + _ensurePath(url);
+export async function apiGET(url, omitPrefix = false) {
+    url = omitPrefix ? _ensurePath(url) : API_URL + _ensurePath(url);
     let resp = null;
     try {
         resp = await axios.get(url);
@@ -201,8 +201,8 @@ export async function apiGET(url) {
  * @param {object} body The body of the post request -- `JSON.stringify` will be called on this object.
  * @returns
  */
-export async function apiPOST(url, body = {}) {
-    url = API_URL + _ensurePath(url);
+export async function apiPOST(url, body = {}, omitPrefix = false) {
+    url = omitPrefix ? _ensurePath(url) : API_URL + _ensurePath(url);
     let resp = null;
     try {
         resp = await axios.post(url, body);


### PR DESCRIPTION
This omitting prefix functionality is required when testing public routes that are used in the frontend and do not include the API_URL prefix.