### PR TITLE
Fix DDAH permissions

### DIFF
--- a/backend/app/controllers/api/v1/admin/ddahs_controller.rb
+++ b/backend/app/controllers/api/v1/admin/ddahs_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-class Api::V1::Admin::DdahsController < ApplicationController
-    # GET /sessions/:session_id/ddahs
+class Api::V1::Admin::DdahsController < ApplicationController # GET /sessions/:session_id/ddahs
     def index
         render_success Ddah.by_session(params[:session_id])
     end
@@ -33,25 +32,18 @@ class Api::V1::Admin::DdahsController < ApplicationController
 
     # GET /assignments/:id/ddah
     def show_by_assignment
-        # Because we are being routed through `/assignments`, the param is :id
-        # and not :assignment_id
         assignment = Assignment.find(params[:id])
         render_success assignment.ddah
     end
 
     # POST /assignments/:id/ddah
     def upsert_by_assignment
-        # We'll mangle the `params` variable in place and fall back to the
-        # usual `create` function
-        # Because we are being routed through `/assignments`, the param is :id
-        # and not :assignment_id
         params[:assignment_id] = params[:id]
         create
     end
 
     # POST /ddahs
     def create
-        # look up the DDAH first by assignment ID, otherwise, create a new DDAH
         @ddah =
             if params[:assignment_id]
                 Assignment.find_by(id: params[:assignment_id]).ddah ||
@@ -88,11 +80,10 @@ class Api::V1::Admin::DdahsController < ApplicationController
     def delete
         find_ddah
         render_on_condition(
-          object: @ddah,
-          condition: proc { @ddah.destroy! },
-          error_message:
-            "Could not delete ddah '#{@ddah.id}'."
-      )
+            object: @ddah,
+            condition: proc { @ddah.destroy! },
+            error_message: "Could not delete ddah '#{@ddah.id}'."
+        )
     end
 
     # POST /ddahs/:ddah_id/email
@@ -115,9 +106,7 @@ class Api::V1::Admin::DdahsController < ApplicationController
     end
 
     def ddah_params
-        params.slice(
-            :assignment_id,
-        ).permit!
+        params.slice(:assignment_id).permit!
     end
 
     def update
@@ -136,11 +125,9 @@ class Api::V1::Admin::DdahsController < ApplicationController
         template_file = "#{contract_dir}/ddah-signature-list.html"
 
         # Verify that the template file is actually contained in the template directory
-        unless Pathname
-                   .new(template_file)
-                   .realdirpath
-                   .to_s
-                   .starts_with?(contract_dir.to_s)
+        unless Pathname.new(template_file).realdirpath.to_s.starts_with?(
+                   contract_dir.to_s
+               )
             raise StandardError, "Invalid contract path #{template_file}"
         end
 
@@ -163,19 +150,17 @@ class Api::V1::Admin::DdahsController < ApplicationController
     # Prepare a hash to be used by a Liquid
     # template based on the ddahs list
     def ddah_signature_list_substitutions(ddahs)
-        ddahs
-            .map do |x|
-                {
-                    position_code: x.assignment.position.position_code,
-                    hours: x.hours,
-                    first_name: x.assignment.applicant.first_name,
-                    last_name: x.assignment.applicant.last_name,
-                    signature: x.signature,
-                    signed_date: x.accepted_date
-                }
-            end
-            .sort_by { |x| [x[:position_code], x[:last_name], x[:first_name]] }
-            .as_json
-            .map(&:stringify_keys)
-    end
+        ddahs.map do |x|
+            {
+                position_code: x.assignment.position.position_code,
+                hours: x.hours,
+                first_name: x.assignment.applicant.first_name,
+                last_name: x.assignment.applicant.last_name,
+                signature: x.signature,
+                signed_date: x.accepted_date
+            }
+        end.sort_by do |x|
+            [x[:position_code], x[:last_name], x[:first_name]]
+        end.as_json.map(&:stringify_keys)
+    end # look up the DDAH first by assignment ID, otherwise, create a new DDAH
 end

--- a/backend/app/controllers/api/v1/admin/ddahs_controller.rb
+++ b/backend/app/controllers/api/v1/admin/ddahs_controller.rb
@@ -117,16 +117,7 @@ class Api::V1::Admin::DdahsController < ApplicationController
     def ddah_params
         params.slice(
             :assignment_id,
-            :approved_date,
-            :accepted_date,
-            :revised_date,
-            :emailed_date,
-            :signature
         ).permit!
-    end
-
-    def duty_params
-        params.slice(:duties).permit(duties: %i[order hours description])
     end
 
     def update

--- a/backend/app/controllers/api/v1/instructor/ddahs_controller.rb
+++ b/backend/app/controllers/api/v1/instructor/ddahs_controller.rb
@@ -80,16 +80,7 @@ class Api::V1::Instructor::DdahsController < ApplicationController
     def ddah_params
         params.slice(
             :assignment_id,
-            :approved_date,
-            :accepted_date,
-            :revised_date,
-            :emailed_date,
-            :signature
         ).permit!
-    end
-
-    def duty_params
-        params.slice(:duties).permit(duties: %i[order hours description])
     end
 
     def update

--- a/backend/app/controllers/api/v1/instructor/ddahs_controller.rb
+++ b/backend/app/controllers/api/v1/instructor/ddahs_controller.rb
@@ -5,9 +5,9 @@ class Api::V1::Instructor::DdahsController < ApplicationController
 
     # GET /sessions/:session_id/ddahs
     def index
-        render_success Ddah
-                           .by_session(params[:session_id])
-                           .by_instructor(@active_instructor.id)
+        render_success Ddah.by_session(params[:session_id]).by_instructor(
+                           @active_instructor.id
+                       )
     end
 
     # GET /ddahs/:ddah_id
@@ -78,9 +78,7 @@ class Api::V1::Instructor::DdahsController < ApplicationController
     end
 
     def ddah_params
-        params.slice(
-            :assignment_id,
-        ).permit!
+        params.slice(:assignment_id).permit!
     end
 
     def update

--- a/backend/app/controllers/api/v1/instructor/ddahs_controller.rb
+++ b/backend/app/controllers/api/v1/instructor/ddahs_controller.rb
@@ -5,9 +5,9 @@ class Api::V1::Instructor::DdahsController < ApplicationController
 
     # GET /sessions/:session_id/ddahs
     def index
-        render_success Ddah.by_session(params[:session_id]).by_instructor(
-                           @active_instructor.id
-                       )
+        render_success Ddah
+                           .by_session(params[:session_id])
+                           .by_instructor(@active_instructor.id)
     end
 
     # GET /ddahs/:ddah_id

--- a/backend/app/models/ddah.rb
+++ b/backend/app/models/ddah.rb
@@ -2,7 +2,7 @@
 
 class Ddah < ApplicationRecord
     belongs_to :assignment
-    has_many :duties, dependent: :destroy
+    has_many :duties, -> { order(:order) }, dependent: :destroy
     accepts_nested_attributes_for :duties
 
     has_secure_token :url_token

--- a/backend/app/services/ddah_service.rb
+++ b/backend/app/services/ddah_service.rb
@@ -123,7 +123,6 @@ class DdahService
             :assignment_id,
             :approved_date,
             :accepted_date,
-            :revised_date,
             :emailed_date,
             :signature
         ).permit!

--- a/backend/app/services/ddah_service.rb
+++ b/backend/app/services/ddah_service.rb
@@ -12,8 +12,7 @@ class DdahService
     def update!
         start_transaction_and_rollback_on_exception do
             @ddah.update!(ddah_params)
-            if duty_params[:duties] && @ddah.duties
-                # Save the old duties to detect if they get changed
+            if duty_params[:duties] && @ddah.duties # Save the old duties to detect if they get changed
                 old_duties = @ddah.duties.as_json(only: %i[description hours])
 
                 # if we specified duties, delete the old ones and add the new ones
@@ -23,10 +22,7 @@ class DdahService
             if duty_params[:duties]
                 @ddah.duties_attributes =
                     duty_params[:duties].map do |duty|
-                        if duty[:description]
-                            # make sure all duties descriptions are normalized
-                            # to start with the appropriate prefixes whenever duties are updated.
-
+                        if duty[:description] # to start with the appropriate prefixes whenever duties are updated.
                             duty[:description] =
                                 self.class.normalize_duty_desc duty[
                                                                    :description
@@ -119,13 +115,7 @@ class DdahService
     end
 
     def ddah_params
-        @params.slice(
-            :assignment_id,
-            :approved_date,
-            :accepted_date,
-            :emailed_date,
-            :signature
-        ).permit!
+        @params.slice(:assignment_id).permit!
     end
 
     def duty_params

--- a/backend/app/services/ddah_service.rb
+++ b/backend/app/services/ddah_service.rb
@@ -12,7 +12,8 @@ class DdahService
     def update!
         start_transaction_and_rollback_on_exception do
             @ddah.update!(ddah_params)
-            if duty_params[:duties] && @ddah.duties # Save the old duties to detect if they get changed
+            if duty_params[:duties] && @ddah.duties
+                # Save the old duties to detect if they get changed
                 old_duties = @ddah.duties.as_json(only: %i[description hours])
 
                 # if we specified duties, delete the old ones and add the new ones
@@ -22,7 +23,10 @@ class DdahService
             if duty_params[:duties]
                 @ddah.duties_attributes =
                     duty_params[:duties].map do |duty|
-                        if duty[:description] # to start with the appropriate prefixes whenever duties are updated.
+                        if duty[:description]
+                            # make sure all duties descriptions are normalized
+                            # to start with the appropriate prefixes whenever duties are updated.
+
                             duty[:description] =
                                 self.class.normalize_duty_desc duty[
                                                                    :description

--- a/backend/docs/erd.svg
+++ b/backend/docs/erd.svg
@@ -62,7 +62,7 @@
 <text text-anchor="start" x="288" y="-621.63" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
 </g>
 <!-- m_ActiveStorage::Blob&#45;&gt;m_ActiveStorage::Attachment -->
-<g id="edge22" class="edge">
+<g id="edge19" class="edge">
 <title>m_ActiveStorage::Blob&#45;&gt;m_ActiveStorage::Attachment</title>
 <path fill="none" stroke="black" d="M361.09,-705.54C372.86,-709.72 385.11,-713.33 397,-715.63 474.24,-730.57 496.66,-730.03 574,-715.63 582.97,-713.96 592.14,-711.6 601.18,-708.83"/>
 <polygon fill="black" stroke="black" points="602.2,-711.81 609.81,-706.06 600.28,-705.81 602.2,-711.81"/>
@@ -90,7 +90,7 @@
 <polygon fill="black" stroke="black" points="392.78,-675.78 401.78,-672.63 392.78,-669.48 392.78,-675.78"/>
 </g>
 <!-- m_ActiveStorage::VariantRecord&#45;&gt;m_ActiveStorage::Attachment -->
-<g id="edge23" class="edge">
+<g id="edge20" class="edge">
 <title>m_ActiveStorage::VariantRecord&#45;&gt;m_ActiveStorage::Attachment</title>
 <path fill="none" stroke="black" d="M569.17,-672.63C579.57,-672.63 590.23,-672.63 600.67,-672.63"/>
 <polygon fill="black" stroke="black" points="600.78,-675.78 609.78,-672.63 600.78,-669.48 600.78,-675.78"/>
@@ -148,7 +148,7 @@
 <text text-anchor="start" x="423.5" y="-338.63" font-family="Arial Italic" font-size="10.00" fill="#999999">integer</text>
 </g>
 <!-- m_Applicant&#45;&gt;m_Application -->
-<g id="edge16" class="edge">
+<g id="edge15" class="edge">
 <title>m_Applicant&#45;&gt;m_Application</title>
 <path fill="none" stroke="black" d="M361.04,-491.47C371.25,-486.27 381.87,-480.87 392.41,-475.5"/>
 <polygon fill="black" stroke="black" points="393.85,-478.3 400.44,-471.41 390.99,-472.69 393.85,-478.3"/>
@@ -175,19 +175,19 @@
 <text text-anchor="start" x="668.5" y="-448.63" font-family="Arial Italic" font-size="10.00" fill="#999999">datetime</text>
 </g>
 <!-- m_Applicant&#45;&gt;m_Assignment -->
-<g id="edge4" class="edge">
+<g id="edge14" class="edge">
 <title>m_Applicant&#45;&gt;m_Assignment</title>
 <path fill="none" stroke="black" d="M361.24,-541.15C419.06,-549.85 502.44,-557.24 574,-543.63 584.46,-541.64 595.2,-538.69 605.68,-535.24"/>
 <polygon fill="black" stroke="black" points="606.92,-538.14 614.41,-532.23 604.87,-532.18 606.92,-538.14"/>
 </g>
 <!-- m_Application&#45;&gt;m_ActiveStorage::Attachment -->
-<g id="edge24" class="edge">
+<g id="edge21" class="edge">
 <title>m_Application&#45;&gt;m_ActiveStorage::Attachment</title>
 <path fill="none" stroke="black" d="M567.73,-528.23C594.76,-561.37 623.65,-596.8 646.06,-624.27"/>
 <polygon fill="black" stroke="black" points="643.77,-626.45 651.9,-631.44 648.66,-622.47 643.77,-626.45"/>
 </g>
 <!-- m_Application&#45;&gt;m_ActiveStorage::Blob -->
-<g id="edge25" class="edge">
+<g id="edge22" class="edge">
 <title>m_Application&#45;&gt;m_ActiveStorage::Blob</title>
 <path fill="none" stroke="black" stroke-dasharray="1,5" d="M414.23,-528.27C397.3,-551.13 378.92,-575.04 361,-596.63 358.79,-599.29 356.52,-601.97 354.21,-604.66"/>
 <polygon fill="black" stroke="black" points="351.53,-602.95 347.99,-611.8 356.27,-607.09 351.53,-602.95"/>
@@ -206,7 +206,7 @@
 <text text-anchor="start" x="695.5" y="-349.63" font-family="Arial Italic" font-size="10.00" fill="#999999">integer</text>
 </g>
 <!-- m_Application&#45;&gt;m_PositionPreference -->
-<g id="edge21" class="edge">
+<g id="edge18" class="edge">
 <title>m_Application&#45;&gt;m_PositionPreference</title>
 <path fill="none" stroke="black" d="M570.61,-405.81C581.82,-402.76 593.3,-399.65 604.47,-396.62"/>
 <polygon fill="black" stroke="black" points="605.48,-399.61 613.34,-394.21 603.83,-393.53 605.48,-399.61"/>
@@ -233,7 +233,7 @@
 <text text-anchor="start" x="849" y="-233.63" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
 </g>
 <!-- m_Assignment&#45;&gt;m_Ddah -->
-<g id="edge3" class="edge">
+<g id="edge5" class="edge">
 <title>m_Assignment&#45;&gt;m_Ddah</title>
 <path fill="none" stroke="black" d="M750.38,-439.11C754.81,-434.02 759.07,-428.82 763,-423.63 782.68,-397.59 779.37,-385.7 799,-359.63 802.63,-354.81 806.56,-349.98 810.64,-345.24"/>
 </g>
@@ -295,7 +295,7 @@
 <text text-anchor="start" x="878" y="-384.63" font-family="Arial Italic" font-size="10.00" fill="#999999">datetime</text>
 </g>
 <!-- m_Assignment&#45;&gt;m_Offer -->
-<g id="edge1" class="edge">
+<g id="edge16" class="edge">
 <title>m_Assignment&#45;&gt;m_Offer</title>
 <path fill="none" stroke="black" d="M758.69,-519.97C768.99,-522.91 779.66,-525.96 790.16,-528.96"/>
 <polygon fill="black" stroke="black" points="789.41,-532.02 798.93,-531.47 791.14,-525.96 789.41,-532.02"/>
@@ -318,7 +318,7 @@
 <text text-anchor="start" x="853" y="-108.63" font-family="Arial Italic" font-size="10.00" fill="#999999">datetime</text>
 </g>
 <!-- m_Assignment&#45;&gt;m_WageChunk -->
-<g id="edge2" class="edge">
+<g id="edge17" class="edge">
 <title>m_Assignment&#45;&gt;m_WageChunk</title>
 <path fill="none" stroke="black" d="M753.52,-439.06C757.07,-434.08 760.28,-428.93 763,-423.63 807.22,-337.43 750.89,-292.73 799,-208.63 800.33,-206.31 801.77,-204.04 803.32,-201.82"/>
 <polygon fill="black" stroke="black" points="805.98,-203.54 808.95,-194.48 800.98,-199.71 805.98,-203.54"/>
@@ -368,7 +368,7 @@
 <text text-anchor="start" x="451.5" y="-63.63" font-family="Arial Italic" font-size="10.00" fill="#999999">datetime</text>
 </g>
 <!-- m_ContractTemplate&#45;&gt;m_Position -->
-<g id="edge11" class="edge">
+<g id="edge13" class="edge">
 <title>m_ContractTemplate&#45;&gt;m_Position</title>
 <path fill="none" stroke="black" d="M361.04,-100.29C369.93,-103.63 379.14,-107.09 388.33,-110.54"/>
 <polygon fill="black" stroke="black" points="387.23,-113.49 396.76,-113.7 389.44,-107.59 387.23,-113.49"/>
@@ -389,7 +389,7 @@
 <text text-anchor="start" x="1017" y="-253.63" font-family="Arial Italic" font-size="10.00" fill="#999999">integer</text>
 </g>
 <!-- m_Ddah&#45;&gt;m_Duty -->
-<g id="edge18" class="edge">
+<g id="edge6" class="edge">
 <title>m_Ddah&#45;&gt;m_Duty</title>
 <path fill="none" stroke="black" d="M949.14,-284.63C957.91,-284.63 966.89,-284.63 975.74,-284.63"/>
 <polygon fill="black" stroke="black" points="975.89,-287.78 984.89,-284.63 975.89,-281.48 975.89,-287.78"/>
@@ -410,20 +410,20 @@
 <text text-anchor="start" x="252" y="-148.63" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗ U</text>
 </g>
 <!-- m_Instructor&#45;&gt;m_Position -->
-<g id="edge6" class="edge">
+<g id="edge9" class="edge">
 <title>m_Instructor&#45;&gt;m_Position</title>
 <path fill="none" stroke="black" d="M370.12,-166.04C375.89,-165.06 381.74,-164.07 387.59,-163.07"/>
 <polygon fill="black" stroke="black" points="369.39,-162.96 361.04,-167.58 370.44,-169.18 369.39,-162.96"/>
 <polygon fill="black" stroke="black" points="388.42,-166.13 396.76,-161.52 387.36,-159.92 388.42,-166.13"/>
 </g>
 <!-- m_Position&#45;&gt;m_Assignment -->
-<g id="edge5" class="edge">
+<g id="edge10" class="edge">
 <title>m_Position&#45;&gt;m_Assignment</title>
 <path fill="none" stroke="black" d="M538.81,-239.81C551.14,-263.52 563.69,-289.2 574,-313.63 594.01,-361.02 583.15,-379.75 610,-423.63 611.6,-426.25 613.31,-428.84 615.11,-431.41"/>
 <polygon fill="black" stroke="black" points="612.85,-433.65 620.73,-439.01 617.91,-429.9 612.85,-433.65"/>
 </g>
 <!-- m_Position&#45;&gt;m_PositionPreference -->
-<g id="edge8" class="edge">
+<g id="edge11" class="edge">
 <title>m_Position&#45;&gt;m_PositionPreference</title>
 <path fill="none" stroke="black" d="M541.3,-239.63C560.87,-268.68 584.46,-299.64 610,-324.63 613.36,-327.91 616.95,-331.11 620.7,-334.2"/>
 <polygon fill="black" stroke="black" points="619.02,-336.89 628.04,-339.99 622.92,-331.94 619.02,-336.89"/>
@@ -444,7 +444,7 @@
 <text text-anchor="start" x="669.5" y="-237.63" font-family="Arial Italic" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
 </g>
 <!-- m_Position&#45;&gt;m_PostingPosition -->
-<g id="edge17" class="edge">
+<g id="edge25" class="edge">
 <title>m_Position&#45;&gt;m_PostingPosition</title>
 <path fill="none" stroke="black" d="M574.07,-200.32C586.31,-207.82 598.78,-215.47 610.75,-222.8"/>
 <polygon fill="black" stroke="black" points="609.21,-225.55 618.53,-227.57 612.5,-220.18 609.21,-225.55"/>
@@ -463,7 +463,7 @@
 <text text-anchor="start" x="692.5" y="-121.63" font-family="Arial Italic" font-size="10.00" fill="#999999">integer (8) FK</text>
 </g>
 <!-- m_Position&#45;&gt;m_ReportingTag -->
-<g id="edge7" class="edge">
+<g id="edge8" class="edge">
 <title>m_Position&#45;&gt;m_ReportingTag</title>
 <path fill="none" stroke="black" d="M583.11,-146.63C590.19,-146.63 597.3,-146.63 604.28,-146.63"/>
 <polygon fill="black" stroke="black" points="583.07,-143.48 574.07,-146.63 583.07,-149.78 583.07,-143.48"/>
@@ -493,19 +493,19 @@
 <text text-anchor="start" x="267" y="-260.63" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
 </g>
 <!-- m_Posting&#45;&gt;m_Application -->
-<g id="edge15" class="edge">
+<g id="edge23" class="edge">
 <title>m_Posting&#45;&gt;m_Application</title>
 <path fill="none" stroke="black" d="M361.04,-358.17C371.25,-364 381.87,-370.06 392.41,-376.07"/>
 <polygon fill="black" stroke="black" points="391.07,-378.93 400.44,-380.66 394.19,-373.46 391.07,-378.93"/>
 </g>
 <!-- m_Posting&#45;&gt;m_PostingPosition -->
-<g id="edge14" class="edge">
+<g id="edge24" class="edge">
 <title>m_Posting&#45;&gt;m_PostingPosition</title>
 <path fill="none" stroke="black" d="M361.16,-308.81C429.84,-300.3 533.65,-287.44 605.24,-278.57"/>
 <polygon fill="black" stroke="black" points="605.7,-281.69 614.24,-277.46 604.92,-275.44 605.7,-281.69"/>
 </g>
 <!-- m_ReportingTag&#45;&gt;m_WageChunk -->
-<g id="edge19" class="edge">
+<g id="edge7" class="edge">
 <title>m_ReportingTag&#45;&gt;m_WageChunk</title>
 <path fill="none" stroke="black" d="M768.4,-146.63C775.33,-146.63 782.35,-146.63 789.29,-146.63"/>
 <polygon fill="black" stroke="black" points="768.22,-143.48 759.22,-146.63 768.22,-149.78 768.22,-143.48"/>
@@ -529,25 +529,25 @@
 <text text-anchor="start" x="72.5" y="-157.63" font-family="Arial Italic" font-size="10.00" fill="#999999">datetime</text>
 </g>
 <!-- m_Session&#45;&gt;m_Application -->
-<g id="edge20" class="edge">
+<g id="edge1" class="edge">
 <title>m_Session&#45;&gt;m_Application</title>
 <path fill="none" stroke="black" d="M162.93,-237.53C169.71,-243.62 175.94,-250.33 181,-257.63 218.12,-311.12 167.85,-356.93 217,-399.63 263.95,-440.41 334.41,-446.62 391.23,-443.19"/>
 <polygon fill="black" stroke="black" points="391.47,-446.33 400.23,-442.56 391.03,-440.04 391.47,-446.33"/>
 </g>
 <!-- m_Session&#45;&gt;m_ContractTemplate -->
-<g id="edge12" class="edge">
+<g id="edge4" class="edge">
 <title>m_Session&#45;&gt;m_ContractTemplate</title>
 <path fill="none" stroke="black" d="M162.72,-151.41C182.98,-138.83 204.91,-125.22 224.67,-112.95"/>
 <polygon fill="black" stroke="black" points="226.44,-115.56 232.42,-108.14 223.11,-110.21 226.44,-115.56"/>
 </g>
 <!-- m_Session&#45;&gt;m_Position -->
-<g id="edge10" class="edge">
+<g id="edge2" class="edge">
 <title>m_Session&#45;&gt;m_Position</title>
 <path fill="none" stroke="black" d="M162.86,-152.17C169.57,-146.18 175.79,-139.65 181,-132.63 211.4,-91.65 175.65,-53.52 217,-23.63 268.87,13.86 301.85,0.8 361,-23.63 375.26,-29.52 388.74,-37.94 401.19,-47.66"/>
 <polygon fill="black" stroke="black" points="399.42,-50.28 408.39,-53.52 403.4,-45.4 399.42,-50.28"/>
 </g>
 <!-- m_Session&#45;&gt;m_Posting -->
-<g id="edge13" class="edge">
+<g id="edge3" class="edge">
 <title>m_Session&#45;&gt;m_Posting</title>
 <path fill="none" stroke="black" d="M162.72,-239.85C177.68,-249.14 193.56,-258.99 208.79,-268.45"/>
 <polygon fill="black" stroke="black" points="207.39,-271.29 216.69,-273.36 210.71,-265.94 207.39,-271.29"/>

--- a/backend/docs/erd.svg
+++ b/backend/docs/erd.svg
@@ -62,7 +62,7 @@
 <text text-anchor="start" x="288" y="-621.63" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗</text>
 </g>
 <!-- m_ActiveStorage::Blob&#45;&gt;m_ActiveStorage::Attachment -->
-<g id="edge19" class="edge">
+<g id="edge22" class="edge">
 <title>m_ActiveStorage::Blob&#45;&gt;m_ActiveStorage::Attachment</title>
 <path fill="none" stroke="black" d="M361.09,-705.54C372.86,-709.72 385.11,-713.33 397,-715.63 474.24,-730.57 496.66,-730.03 574,-715.63 582.97,-713.96 592.14,-711.6 601.18,-708.83"/>
 <polygon fill="black" stroke="black" points="602.2,-711.81 609.81,-706.06 600.28,-705.81 602.2,-711.81"/>
@@ -90,7 +90,7 @@
 <polygon fill="black" stroke="black" points="392.78,-675.78 401.78,-672.63 392.78,-669.48 392.78,-675.78"/>
 </g>
 <!-- m_ActiveStorage::VariantRecord&#45;&gt;m_ActiveStorage::Attachment -->
-<g id="edge20" class="edge">
+<g id="edge23" class="edge">
 <title>m_ActiveStorage::VariantRecord&#45;&gt;m_ActiveStorage::Attachment</title>
 <path fill="none" stroke="black" d="M569.17,-672.63C579.57,-672.63 590.23,-672.63 600.67,-672.63"/>
 <polygon fill="black" stroke="black" points="600.78,-675.78 609.78,-672.63 600.78,-669.48 600.78,-675.78"/>
@@ -148,7 +148,7 @@
 <text text-anchor="start" x="423.5" y="-338.63" font-family="Arial Italic" font-size="10.00" fill="#999999">integer</text>
 </g>
 <!-- m_Applicant&#45;&gt;m_Application -->
-<g id="edge15" class="edge">
+<g id="edge16" class="edge">
 <title>m_Applicant&#45;&gt;m_Application</title>
 <path fill="none" stroke="black" d="M361.04,-491.47C371.25,-486.27 381.87,-480.87 392.41,-475.5"/>
 <polygon fill="black" stroke="black" points="393.85,-478.3 400.44,-471.41 390.99,-472.69 393.85,-478.3"/>
@@ -175,19 +175,19 @@
 <text text-anchor="start" x="668.5" y="-448.63" font-family="Arial Italic" font-size="10.00" fill="#999999">datetime</text>
 </g>
 <!-- m_Applicant&#45;&gt;m_Assignment -->
-<g id="edge14" class="edge">
+<g id="edge4" class="edge">
 <title>m_Applicant&#45;&gt;m_Assignment</title>
 <path fill="none" stroke="black" d="M361.24,-541.15C419.06,-549.85 502.44,-557.24 574,-543.63 584.46,-541.64 595.2,-538.69 605.68,-535.24"/>
 <polygon fill="black" stroke="black" points="606.92,-538.14 614.41,-532.23 604.87,-532.18 606.92,-538.14"/>
 </g>
 <!-- m_Application&#45;&gt;m_ActiveStorage::Attachment -->
-<g id="edge21" class="edge">
+<g id="edge24" class="edge">
 <title>m_Application&#45;&gt;m_ActiveStorage::Attachment</title>
 <path fill="none" stroke="black" d="M567.73,-528.23C594.76,-561.37 623.65,-596.8 646.06,-624.27"/>
 <polygon fill="black" stroke="black" points="643.77,-626.45 651.9,-631.44 648.66,-622.47 643.77,-626.45"/>
 </g>
 <!-- m_Application&#45;&gt;m_ActiveStorage::Blob -->
-<g id="edge22" class="edge">
+<g id="edge25" class="edge">
 <title>m_Application&#45;&gt;m_ActiveStorage::Blob</title>
 <path fill="none" stroke="black" stroke-dasharray="1,5" d="M414.23,-528.27C397.3,-551.13 378.92,-575.04 361,-596.63 358.79,-599.29 356.52,-601.97 354.21,-604.66"/>
 <polygon fill="black" stroke="black" points="351.53,-602.95 347.99,-611.8 356.27,-607.09 351.53,-602.95"/>
@@ -206,7 +206,7 @@
 <text text-anchor="start" x="695.5" y="-349.63" font-family="Arial Italic" font-size="10.00" fill="#999999">integer</text>
 </g>
 <!-- m_Application&#45;&gt;m_PositionPreference -->
-<g id="edge18" class="edge">
+<g id="edge21" class="edge">
 <title>m_Application&#45;&gt;m_PositionPreference</title>
 <path fill="none" stroke="black" d="M570.61,-405.81C581.82,-402.76 593.3,-399.65 604.47,-396.62"/>
 <polygon fill="black" stroke="black" points="605.48,-399.61 613.34,-394.21 603.83,-393.53 605.48,-399.61"/>
@@ -233,7 +233,7 @@
 <text text-anchor="start" x="849" y="-233.63" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
 </g>
 <!-- m_Assignment&#45;&gt;m_Ddah -->
-<g id="edge5" class="edge">
+<g id="edge3" class="edge">
 <title>m_Assignment&#45;&gt;m_Ddah</title>
 <path fill="none" stroke="black" d="M750.38,-439.11C754.81,-434.02 759.07,-428.82 763,-423.63 782.68,-397.59 779.37,-385.7 799,-359.63 802.63,-354.81 806.56,-349.98 810.64,-345.24"/>
 </g>
@@ -295,7 +295,7 @@
 <text text-anchor="start" x="878" y="-384.63" font-family="Arial Italic" font-size="10.00" fill="#999999">datetime</text>
 </g>
 <!-- m_Assignment&#45;&gt;m_Offer -->
-<g id="edge16" class="edge">
+<g id="edge1" class="edge">
 <title>m_Assignment&#45;&gt;m_Offer</title>
 <path fill="none" stroke="black" d="M758.69,-519.97C768.99,-522.91 779.66,-525.96 790.16,-528.96"/>
 <polygon fill="black" stroke="black" points="789.41,-532.02 798.93,-531.47 791.14,-525.96 789.41,-532.02"/>
@@ -318,7 +318,7 @@
 <text text-anchor="start" x="853" y="-108.63" font-family="Arial Italic" font-size="10.00" fill="#999999">datetime</text>
 </g>
 <!-- m_Assignment&#45;&gt;m_WageChunk -->
-<g id="edge17" class="edge">
+<g id="edge2" class="edge">
 <title>m_Assignment&#45;&gt;m_WageChunk</title>
 <path fill="none" stroke="black" d="M753.52,-439.06C757.07,-434.08 760.28,-428.93 763,-423.63 807.22,-337.43 750.89,-292.73 799,-208.63 800.33,-206.31 801.77,-204.04 803.32,-201.82"/>
 <polygon fill="black" stroke="black" points="805.98,-203.54 808.95,-194.48 800.98,-199.71 805.98,-203.54"/>
@@ -368,7 +368,7 @@
 <text text-anchor="start" x="451.5" y="-63.63" font-family="Arial Italic" font-size="10.00" fill="#999999">datetime</text>
 </g>
 <!-- m_ContractTemplate&#45;&gt;m_Position -->
-<g id="edge13" class="edge">
+<g id="edge11" class="edge">
 <title>m_ContractTemplate&#45;&gt;m_Position</title>
 <path fill="none" stroke="black" d="M361.04,-100.29C369.93,-103.63 379.14,-107.09 388.33,-110.54"/>
 <polygon fill="black" stroke="black" points="387.23,-113.49 396.76,-113.7 389.44,-107.59 387.23,-113.49"/>
@@ -389,7 +389,7 @@
 <text text-anchor="start" x="1017" y="-253.63" font-family="Arial Italic" font-size="10.00" fill="#999999">integer</text>
 </g>
 <!-- m_Ddah&#45;&gt;m_Duty -->
-<g id="edge6" class="edge">
+<g id="edge18" class="edge">
 <title>m_Ddah&#45;&gt;m_Duty</title>
 <path fill="none" stroke="black" d="M949.14,-284.63C957.91,-284.63 966.89,-284.63 975.74,-284.63"/>
 <polygon fill="black" stroke="black" points="975.89,-287.78 984.89,-284.63 975.89,-281.48 975.89,-287.78"/>
@@ -410,20 +410,20 @@
 <text text-anchor="start" x="252" y="-148.63" font-family="Arial Italic" font-size="10.00" fill="#999999">string ∗ U</text>
 </g>
 <!-- m_Instructor&#45;&gt;m_Position -->
-<g id="edge9" class="edge">
+<g id="edge6" class="edge">
 <title>m_Instructor&#45;&gt;m_Position</title>
 <path fill="none" stroke="black" d="M370.12,-166.04C375.89,-165.06 381.74,-164.07 387.59,-163.07"/>
 <polygon fill="black" stroke="black" points="369.39,-162.96 361.04,-167.58 370.44,-169.18 369.39,-162.96"/>
 <polygon fill="black" stroke="black" points="388.42,-166.13 396.76,-161.52 387.36,-159.92 388.42,-166.13"/>
 </g>
 <!-- m_Position&#45;&gt;m_Assignment -->
-<g id="edge10" class="edge">
+<g id="edge5" class="edge">
 <title>m_Position&#45;&gt;m_Assignment</title>
 <path fill="none" stroke="black" d="M538.81,-239.81C551.14,-263.52 563.69,-289.2 574,-313.63 594.01,-361.02 583.15,-379.75 610,-423.63 611.6,-426.25 613.31,-428.84 615.11,-431.41"/>
 <polygon fill="black" stroke="black" points="612.85,-433.65 620.73,-439.01 617.91,-429.9 612.85,-433.65"/>
 </g>
 <!-- m_Position&#45;&gt;m_PositionPreference -->
-<g id="edge11" class="edge">
+<g id="edge8" class="edge">
 <title>m_Position&#45;&gt;m_PositionPreference</title>
 <path fill="none" stroke="black" d="M541.3,-239.63C560.87,-268.68 584.46,-299.64 610,-324.63 613.36,-327.91 616.95,-331.11 620.7,-334.2"/>
 <polygon fill="black" stroke="black" points="619.02,-336.89 628.04,-339.99 622.92,-331.94 619.02,-336.89"/>
@@ -444,7 +444,7 @@
 <text text-anchor="start" x="669.5" y="-237.63" font-family="Arial Italic" font-size="10.00" fill="#999999">integer (8) ∗ FK</text>
 </g>
 <!-- m_Position&#45;&gt;m_PostingPosition -->
-<g id="edge25" class="edge">
+<g id="edge17" class="edge">
 <title>m_Position&#45;&gt;m_PostingPosition</title>
 <path fill="none" stroke="black" d="M574.07,-200.32C586.31,-207.82 598.78,-215.47 610.75,-222.8"/>
 <polygon fill="black" stroke="black" points="609.21,-225.55 618.53,-227.57 612.5,-220.18 609.21,-225.55"/>
@@ -463,7 +463,7 @@
 <text text-anchor="start" x="692.5" y="-121.63" font-family="Arial Italic" font-size="10.00" fill="#999999">integer (8) FK</text>
 </g>
 <!-- m_Position&#45;&gt;m_ReportingTag -->
-<g id="edge8" class="edge">
+<g id="edge7" class="edge">
 <title>m_Position&#45;&gt;m_ReportingTag</title>
 <path fill="none" stroke="black" d="M583.11,-146.63C590.19,-146.63 597.3,-146.63 604.28,-146.63"/>
 <polygon fill="black" stroke="black" points="583.07,-143.48 574.07,-146.63 583.07,-149.78 583.07,-143.48"/>
@@ -493,19 +493,19 @@
 <text text-anchor="start" x="267" y="-260.63" font-family="Arial Italic" font-size="10.00" fill="#999999">string</text>
 </g>
 <!-- m_Posting&#45;&gt;m_Application -->
-<g id="edge23" class="edge">
+<g id="edge15" class="edge">
 <title>m_Posting&#45;&gt;m_Application</title>
 <path fill="none" stroke="black" d="M361.04,-358.17C371.25,-364 381.87,-370.06 392.41,-376.07"/>
 <polygon fill="black" stroke="black" points="391.07,-378.93 400.44,-380.66 394.19,-373.46 391.07,-378.93"/>
 </g>
 <!-- m_Posting&#45;&gt;m_PostingPosition -->
-<g id="edge24" class="edge">
+<g id="edge14" class="edge">
 <title>m_Posting&#45;&gt;m_PostingPosition</title>
 <path fill="none" stroke="black" d="M361.16,-308.81C429.84,-300.3 533.65,-287.44 605.24,-278.57"/>
 <polygon fill="black" stroke="black" points="605.7,-281.69 614.24,-277.46 604.92,-275.44 605.7,-281.69"/>
 </g>
 <!-- m_ReportingTag&#45;&gt;m_WageChunk -->
-<g id="edge7" class="edge">
+<g id="edge19" class="edge">
 <title>m_ReportingTag&#45;&gt;m_WageChunk</title>
 <path fill="none" stroke="black" d="M768.4,-146.63C775.33,-146.63 782.35,-146.63 789.29,-146.63"/>
 <polygon fill="black" stroke="black" points="768.22,-143.48 759.22,-146.63 768.22,-149.78 768.22,-143.48"/>
@@ -529,25 +529,25 @@
 <text text-anchor="start" x="72.5" y="-157.63" font-family="Arial Italic" font-size="10.00" fill="#999999">datetime</text>
 </g>
 <!-- m_Session&#45;&gt;m_Application -->
-<g id="edge1" class="edge">
+<g id="edge20" class="edge">
 <title>m_Session&#45;&gt;m_Application</title>
 <path fill="none" stroke="black" d="M162.93,-237.53C169.71,-243.62 175.94,-250.33 181,-257.63 218.12,-311.12 167.85,-356.93 217,-399.63 263.95,-440.41 334.41,-446.62 391.23,-443.19"/>
 <polygon fill="black" stroke="black" points="391.47,-446.33 400.23,-442.56 391.03,-440.04 391.47,-446.33"/>
 </g>
 <!-- m_Session&#45;&gt;m_ContractTemplate -->
-<g id="edge4" class="edge">
+<g id="edge12" class="edge">
 <title>m_Session&#45;&gt;m_ContractTemplate</title>
 <path fill="none" stroke="black" d="M162.72,-151.41C182.98,-138.83 204.91,-125.22 224.67,-112.95"/>
 <polygon fill="black" stroke="black" points="226.44,-115.56 232.42,-108.14 223.11,-110.21 226.44,-115.56"/>
 </g>
 <!-- m_Session&#45;&gt;m_Position -->
-<g id="edge2" class="edge">
+<g id="edge10" class="edge">
 <title>m_Session&#45;&gt;m_Position</title>
 <path fill="none" stroke="black" d="M162.86,-152.17C169.57,-146.18 175.79,-139.65 181,-132.63 211.4,-91.65 175.65,-53.52 217,-23.63 268.87,13.86 301.85,0.8 361,-23.63 375.26,-29.52 388.74,-37.94 401.19,-47.66"/>
 <polygon fill="black" stroke="black" points="399.42,-50.28 408.39,-53.52 403.4,-45.4 399.42,-50.28"/>
 </g>
 <!-- m_Session&#45;&gt;m_Posting -->
-<g id="edge3" class="edge">
+<g id="edge13" class="edge">
 <title>m_Session&#45;&gt;m_Posting</title>
 <path fill="none" stroke="black" d="M162.72,-239.85C177.68,-249.14 193.56,-258.99 208.79,-268.45"/>
 <polygon fill="black" stroke="black" points="207.39,-271.29 216.69,-273.36 210.71,-265.94 207.39,-271.29"/>

--- a/frontend/src/tests/ddah-tests.js
+++ b/frontend/src/tests/ddah-tests.js
@@ -278,6 +278,7 @@ export function ddahTests(api) {
             { signature: "My Sig" },
             true
         );
+        
         expect(resp).toHaveStatus("success");
         // Get the signed DDAH since it is not returned from public route
         resp = await apiGET(`/admin/assignments/${newAssignment.id}/ddah`);
@@ -285,22 +286,20 @@ export function ddahTests(api) {
         let signedDdah = resp.payload;
         expect(signedDdah.signature).toEqual("My Sig");
         expect(signedDdah.accepted_date).toBeTruthy();
-        console.log("before:", signedDdah);
         // Updating a signed DDAH should remove the signature
         resp = await apiPOST(`/admin/ddahs`, {
             id: signedDdah.id,
             duties: [
                 ...ddah.duties,
                 {
-                    order: 10,
-                    description: "meeting:Hot-pocket eating contest",
+                    order: 11,
+                    description: "meeting:Hot-pocket eating contest 2.0",
                     hours: 6,
                 },
             ],
         });
         expect(resp).toHaveStatus("success");
         signedDdah = resp.payload;
-        console.log(signedDdah);
         expect(signedDdah.signature).toBeFalsy();
         expect(signedDdah.accepted_date).toBeFalsy();
         expect(signedDdah.revised_date).toBeTruthy();

--- a/frontend/src/tests/ddah-tests.js
+++ b/frontend/src/tests/ddah-tests.js
@@ -272,20 +272,21 @@ export function ddahTests(api) {
         expect(resp).toHaveStatus("success");
         expect(resp.payload.approved_date).toBeFalsy();
 
-        // Updating a signed DDAH should remove the signature
-        resp = await apiPOST(`/admin/ddahs`, ddah);
+        // Sign the DDAH
+        resp = await apiPOST(
+            `/public/ddahs/${ddah.url_token}/accept`,
+            { signature: "My Sig" },
+            true
+        );
         expect(resp).toHaveStatus("success");
-        ddah = resp.payload;
-        resp = await apiPOST(`/admin/ddahs`, {
-            ...ddah,
-            signature: "My Sig",
-            accepted_date: new Date(),
-        });
+        // Get the signed DDAH since it is not returned from public route
+        resp = await apiGET(`/admin/assignments/${newAssignment.id}/ddah`);
         expect(resp).toHaveStatus("success");
         let signedDdah = resp.payload;
         expect(signedDdah.signature).toEqual("My Sig");
         expect(signedDdah.accepted_date).toBeTruthy();
-        // Update the list of duties
+
+        // Updating a signed DDAH should remove the signature
         resp = await apiPOST(`/admin/ddahs`, {
             id: signedDdah.id,
             duties: [

--- a/frontend/src/tests/ddah-tests.js
+++ b/frontend/src/tests/ddah-tests.js
@@ -285,7 +285,7 @@ export function ddahTests(api) {
         let signedDdah = resp.payload;
         expect(signedDdah.signature).toEqual("My Sig");
         expect(signedDdah.accepted_date).toBeTruthy();
-
+        console.log("before:", signedDdah);
         // Updating a signed DDAH should remove the signature
         resp = await apiPOST(`/admin/ddahs`, {
             id: signedDdah.id,
@@ -300,6 +300,7 @@ export function ddahTests(api) {
         });
         expect(resp).toHaveStatus("success");
         signedDdah = resp.payload;
+        console.log(signedDdah);
         expect(signedDdah.signature).toBeFalsy();
         expect(signedDdah.accepted_date).toBeFalsy();
         expect(signedDdah.revised_date).toBeTruthy();

--- a/frontend/src/tests/ddah-tests.js
+++ b/frontend/src/tests/ddah-tests.js
@@ -278,7 +278,7 @@ export function ddahTests(api) {
             { signature: "My Sig" },
             true
         );
-        
+
         expect(resp).toHaveStatus("success");
         // Get the signed DDAH since it is not returned from public route
         resp = await apiGET(`/admin/assignments/${newAssignment.id}/ddah`);

--- a/frontend/src/tests/instructor-permission-test.js
+++ b/frontend/src/tests/instructor-permission-test.js
@@ -629,9 +629,7 @@ export function instructorsPermissionTests(api) {
                 ...originalDdah,
                 duties: updatedDuties,
             };
-            expect(resp.payload).toEqual(
-                expect.objectContaining(originalDdahWithUpdatedDuties)
-            );
+            expect(resp.payload).toEqual(originalDdahWithUpdatedDuties);
         });
 
         it("cannot create a Ddah for an assignment not associated with self", async () => {


### PR DESCRIPTION
This PR fixes Issue #608 by restricting which parameters are permitted in ddah controllers for instructors. It also reduces the number of ways one could modify existing ddah by forcing to go through `/accept` `/approve` and `/email` routes instead.

Additionally, some tests are fixed