### PR TITLE
Add open_status for postings to determine whether an application is late

### DIFF
--- a/backend/app/controllers/public/postings_controller.rb
+++ b/backend/app/controllers/public/postings_controller.rb
@@ -16,7 +16,8 @@ class Public::PostingsController < ActionController::Base
         render_success(
             {
                 survey: posting_service.survey,
-                prefilled_data: posting_service.prefill(user: active_user)
+                prefilled_data: posting_service.prefill(user: active_user),
+                open_status: @posting.open_status
             }
         )
     end
@@ -32,8 +33,9 @@ class Public::PostingsController < ActionController::Base
         )
         posting_service.save_answers!
 
-        PostingMailer.email_application_confirmation(posting_service.application)
-            .deliver_now!
+        PostingMailer.email_application_confirmation(
+            posting_service.application
+        ).deliver_now!
         render_success posting_service.prefill(user: active_user)
     rescue StandardError => e
         render_error(message: 'Error submitting application', error: e)

--- a/backend/app/models/posting.rb
+++ b/backend/app/models/posting.rb
@@ -10,4 +10,11 @@ class Posting < ApplicationRecord
     enum availability: POSTING_AVAILABILITY
 
     validates :name, presence: true, uniqueness: { scope: :session }
+
+    def open_status
+        today = Time.now.in_time_zone('Eastern Time (US & Canada)').to_date
+        range_start = open_date.to_date
+        range_end = close_date.to_date
+        (today >= range_start) && (today <= range_end)
+    end
 end

--- a/backend/app/serializers/posting_serializer.rb
+++ b/backend/app/serializers/posting_serializer.rb
@@ -9,7 +9,8 @@ class PostingSerializer < ActiveModel::Serializer
                :availability,
                :custom_questions,
                :application_ids,
-               :url_token
+               :url_token,
+               :open_status
 
     def application_ids
         object.applications.ids

--- a/backend/app/services/application_service.rb
+++ b/backend/app/services/application_service.rb
@@ -32,7 +32,7 @@ class ApplicationService
 
         # Custom question answers are stored as a JSON blob in the database. We unpack them if there are any
         if @application.custom_question_answers
-            data.merge! @application.custom_question_answers
+            data.merge! @application.custom_question_answers.except('utorid')
         end
 
         # Position-preferences must be reconstructed from the database. Surveyjs expects

--- a/backend/app/services/posting_service.rb
+++ b/backend/app/services/posting_service.rb
@@ -21,7 +21,17 @@ class PostingService
             )
 
         # Set the global survey title
-        fixed_survey['title'] = @posting.name
+        availability_desc =
+            if @posting.open_date.year == @posting.close_date.year
+                "Available from #{@posting.open_date.strftime('%b %d')} to #{
+                    @posting.close_date.strftime('%b %d, %Y')
+                }"
+            else
+                "Available from #{
+                    @posting.open_date.strftime('%b %d, %Y')
+                } to #{@posting.close_date.strftime('%b %d, %Y')}"
+            end
+        fixed_survey['title'] = "#{@posting.name} (#{availability_desc})"
         fixed_survey['description'] = @posting.intro_text
 
         # Find the preferences page and set a preference for each PostingPosition
@@ -75,7 +85,8 @@ class PostingService
             phone: applicant.phone
         }
 
-        existing_application = Application.find_by(posting: @posting)
+        existing_application =
+            Application.find_by(posting: @posting, applicant: applicant)
         if existing_application
             application_service =
                 ApplicationService.new application: existing_application

--- a/frontend/src/api/defs/types/minimal-types.ts
+++ b/frontend/src/api/defs/types/minimal-types.ts
@@ -50,7 +50,11 @@ export interface MinimalPostingPosition
 export interface MinimalPosting
     extends Omit<
         NoId<Posting>,
-        "posting_positions" | "applications" | "availability" | "url_token"
+        | "posting_positions"
+        | "applications"
+        | "availability"
+        | "url_token"
+        | "open_status"
     > {
     posting_positions: MinimalPostingPosition[];
 }

--- a/frontend/src/api/defs/types/raw-types.ts
+++ b/frontend/src/api/defs/types/raw-types.ts
@@ -127,6 +127,7 @@ export interface RawPosting extends HasId {
     custom_questions: { pages: { name: string; [key: string]: any }[] } | null;
     application_ids: number[];
     url_token: string;
+    open_status: boolean;
 }
 
 export interface RawPostingPosition {

--- a/frontend/src/views/admin/postings/posting-list.tsx
+++ b/frontend/src/views/admin/postings/posting-list.tsx
@@ -29,7 +29,7 @@ export function ConnectedPostingsList({ editable = true }) {
         );
     }
 
-    // props.original contains the row data for this particular session
+    // props.original contains the row data for this particular posting
     function CellDetailsButton({ row }: Cell<Posting>) {
         const posting = row?.original || {};
         return (
@@ -42,6 +42,11 @@ export function ConnectedPostingsList({ editable = true }) {
                 </Link>
             </div>
         );
+    }
+    function CellAvailability({ row }: Cell<Posting>) {
+        const posting = row?.original || {};
+        const status = posting.open_status ? "Open" : "Closed";
+        return `${status} (${posting.availability})`;
     }
     const DEFAULT_COLUMNS: (Column<Posting> & {
         className?: string;
@@ -72,7 +77,8 @@ export function ConnectedPostingsList({ editable = true }) {
         },
         {
             Header: generateHeaderCell("Availability"),
-            accessor: "availability",
+            id: "availability",
+            Cell: CellAvailability,
         },
     ];
 

--- a/frontend/src/views/public/postings/index.tsx
+++ b/frontend/src/views/public/postings/index.tsx
@@ -6,13 +6,6 @@ import * as Survey from "survey-react";
 import "./survey.css";
 import { Alert, Button, Modal, Spinner } from "react-bootstrap";
 
-// XXX This is a temporary function to make all questions optional during debugging
-function stripIsRequired(obj: any) {
-    let json = JSON.stringify(obj);
-    json = json.replaceAll(`"isRequired":true`, `"isRequired":false`);
-    return JSON.parse(json);
-}
-
 /**
  * Determine whether a survey.js survey has has at least one
  * position preference available. (Surveys that don't have any position
@@ -49,6 +42,7 @@ export function PostingView() {
     const [submissionError, setSubmissionError] = React.useState<string | null>(
         null
     );
+    const [applicationOpen, setApplicationOpen] = React.useState(true);
 
     React.useEffect(() => {
         if (url_token == null) {
@@ -59,16 +53,17 @@ export function PostingView() {
                 const details: {
                     survey: any;
                     prefilled_data: any;
+                    open_status: boolean;
                 } = await apiGET(`/public/postings/${url_token}`, true);
-                //setSurveyJson(stripIsRequired(details.survey));
                 setSurveyJson(details.survey);
                 setSurveyPrefilledData(details.prefilled_data);
+                setApplicationOpen(details.open_status);
             } catch (e) {
                 console.warn(e);
             }
         }
         fetchSurvey();
-    }, [url_token, setSurveyJson, setSurveyPrefilledData]);
+    }, [url_token, setSurveyJson, setSurveyPrefilledData, setApplicationOpen]);
 
     const survey = React.useMemo(() => {
         Survey.StylesManager.applyTheme("bootstrap");
@@ -155,6 +150,13 @@ export function PostingView() {
                     <Modal.Title>Submit Application</Modal.Title>
                 </Modal.Header>
                 <Modal.Body>
+                    {!applicationOpen ? (
+                        <Alert variant="warning">
+                            The application window is currently not open. Any
+                            applications submitted outside of the application
+                            window may not be considered.
+                        </Alert>
+                    ) : null}
                     {submissionError ? (
                         <Alert variant="danger">
                             <b>Error:</b> {submissionError} Please review your


### PR DESCRIPTION
We need to warn users when they are submitting an application outside of the application window. Because of complex time-zone issues, the application availability must be computed server-side.