### PR TITLE
Remove irrelevant application admin tests

### DIFF
--- a/frontend/src/tests/application-tests.js
+++ b/frontend/src/tests/application-tests.js
@@ -2,13 +2,8 @@ import { it, beforeAll } from "./utils";
 import { databaseSeeder } from "./setup";
 
 export function applicationsTests({ apiGET, apiPOST }) {
-    let session, applicant, position;
-
     beforeAll(async () => {
         await databaseSeeder.seed({ apiGET, apiPOST });
-        session = databaseSeeder.seededData.session;
-        applicant = databaseSeeder.seededData.applicant;
-        position = databaseSeeder.seededData.position;
     }, 30000);
 
     // These tests set data through the `/public/postings` route,

--- a/frontend/src/tests/application-tests.js
+++ b/frontend/src/tests/application-tests.js
@@ -2,8 +2,13 @@ import { it, beforeAll } from "./utils";
 import { databaseSeeder } from "./setup";
 
 export function applicationsTests({ apiGET, apiPOST }) {
+    let session, applicant, position;
+
     beforeAll(async () => {
         await databaseSeeder.seed({ apiGET, apiPOST });
+        session = databaseSeeder.seededData.session;
+        applicant = databaseSeeder.seededData.applicant;
+        position = databaseSeeder.seededData.position;
     }, 30000);
 
     // These tests set data through the `/public/postings` route,
@@ -43,10 +48,5 @@ export function applicationsTests({ apiGET, apiPOST }) {
         it.todo(
             "Can submit and retrieve attachments for an updated application"
         );
-    });
-
-    describe("Admin route tests", () => {
-        it.todo("Create an application");
-        it.todo("Update an application");
     });
 }


### PR DESCRIPTION
We are removing the admin route tests because admin should not be able to create applications. Only TA user should be allowed to create them from the public route. Partially addresses issue #590