### PR TITLE
Fallback to null and clear state if deleted session is active.

### DIFF
--- a/frontend/src/api/actions/init.ts
+++ b/frontend/src/api/actions/init.ts
@@ -253,12 +253,17 @@ export function initFromStage(
     };
 }
 
-export function clearSessionDependentData(): ThunkAction<Promise<void>, RootState, void, AnyAction> {
+export function clearSessionDependentData(): ThunkAction<
+    Promise<void>,
+    RootState,
+    void,
+    AnyAction
+> {
     return async (dispatch, getState) => {
         dispatch(fetchApplicantsSuccess([]));
         dispatch(fetchAssignmentsSuccess([]));
         dispatch(fetchContractTemplatesSuccess([]));
         dispatch(fetchApplicationsSuccess([]));
         dispatch(fetchPositionsSuccess([]));
-    }
+    };
 }

--- a/frontend/src/api/actions/init.ts
+++ b/frontend/src/api/actions/init.ts
@@ -253,13 +253,20 @@ export function initFromStage(
     };
 }
 
+/**
+ * Clear all session-specific store data: applicants, assignments,
+ * contract templates, applications, and positions.
+ *
+ * @export
+ * @returns an async function that handles all the API calls.
+ */
 export function clearSessionDependentData(): ThunkAction<
     Promise<void>,
     RootState,
     void,
     AnyAction
 > {
-    return async (dispatch, getState) => {
+    return async (dispatch) => {
         dispatch(fetchApplicantsSuccess([]));
         dispatch(fetchAssignmentsSuccess([]));
         dispatch(fetchContractTemplatesSuccess([]));

--- a/frontend/src/api/actions/init.ts
+++ b/frontend/src/api/actions/init.ts
@@ -229,7 +229,7 @@ export function initFromStage(
             // Before fetching session-related data, the existing data
             // should be cleared. It will be re-fetched via the appropriate routes,
             // but clearing now will prevent excess re-renders as data streams in.
-            dispatch(clearSessionDependentData());
+            await dispatch(clearSessionDependentData());
 
             // `fetchActions` array contains all the fetch API calls that need to be
             // made in order to obtain all data that the app needs.

--- a/frontend/src/api/actions/init.ts
+++ b/frontend/src/api/actions/init.ts
@@ -97,7 +97,7 @@ export function initFromStage(
     stage: InitStages,
     options = { startAfterStage: false }
 ): ThunkAction<Promise<void>, RootState, void, AnyAction> {
-    const startAfterStage = +!!options.startAfterStage;
+    const startAfterStage = options.startAfterStage ? 1 : 0;
 
     return async (dispatch, getState) => {
         const parsedGlobals = { mockAPI: null, activeSession: null };

--- a/frontend/src/api/actions/init.ts
+++ b/frontend/src/api/actions/init.ts
@@ -181,12 +181,8 @@ export function initFromStage(
         if (shouldRunStage("setActiveUserRole")) {
             // When the role is changed, data should be cleared immediately.
             // It will be re-fetched via the appropriate routes.
-            dispatch(fetchApplicantsSuccess([]));
-            dispatch(fetchAssignmentsSuccess([]));
-            dispatch(fetchContractTemplatesSuccess([]));
-            dispatch(fetchApplicationsSuccess([]));
+            dispatch(clearSessionDependentData());
             dispatch(fetchInstructorsSuccess([]));
-            dispatch(fetchPositionsSuccess([]));
 
             const activeRole = activeRoleSelector(getState());
             await dispatch(setActiveUserRole(activeRole, { skipInit: true }));
@@ -233,11 +229,7 @@ export function initFromStage(
             // Before fetching session-related data, the existing data
             // should be cleared. It will be re-fetched via the appropriate routes,
             // but clearing now will prevent excess re-renders as data streams in.
-            dispatch(fetchApplicantsSuccess([]));
-            dispatch(fetchAssignmentsSuccess([]));
-            dispatch(fetchContractTemplatesSuccess([]));
-            dispatch(fetchApplicationsSuccess([]));
-            dispatch(fetchPositionsSuccess([]));
+            dispatch(clearSessionDependentData());
 
             // `fetchActions` array contains all the fetch API calls that need to be
             // made in order to obtain all data that the app needs.
@@ -259,4 +251,14 @@ export function initFromStage(
         // Wait for async actions dispatched earlier to complete.
         await Promise.all(asyncActions);
     };
+}
+
+export function clearSessionDependentData(): ThunkAction<Promise<void>, RootState, void, AnyAction> {
+    return async (dispatch, getState) => {
+        dispatch(fetchApplicantsSuccess([]));
+        dispatch(fetchAssignmentsSuccess([]));
+        dispatch(fetchContractTemplatesSuccess([]));
+        dispatch(fetchApplicationsSuccess([]));
+        dispatch(fetchPositionsSuccess([]));
+    }
 }

--- a/frontend/src/api/actions/sessions.ts
+++ b/frontend/src/api/actions/sessions.ts
@@ -116,7 +116,6 @@ export const setActiveSession = validatedApiDispatcher({
         // passing in null will unset the active session
         if (payload == null) {
             dispatch(setActiveSessionAction(null));
-            // TODO: is this return warranted assuming we want to really unset current session? we need to clear state somewhere
             dispatch(clearSessionDependentData());
             return;
         }

--- a/frontend/src/api/actions/sessions.ts
+++ b/frontend/src/api/actions/sessions.ts
@@ -118,7 +118,7 @@ export const setActiveSession = validatedApiDispatcher({
             dispatch(setActiveSessionAction(null));
             // TODO: is this return warranted assuming we want to really unset current session? we need to clear state somewhere
             dispatch(clearSessionDependentData());
-            return; 
+            return;
         }
         if ((currentActiveSession || { id: null }).id === payload.id) {
             return;

--- a/frontend/src/api/actions/sessions.ts
+++ b/frontend/src/api/actions/sessions.ts
@@ -11,7 +11,7 @@ import { actionFactory, HasId, validatedApiDispatcher } from "./utils";
 import { apiGET, apiPOST } from "../../libs/api-utils";
 import { sessionsReducer } from "../reducers/sessions";
 import { activeRoleSelector } from "./users";
-import { initFromStage } from "./init";
+import { clearSessionDependentData, initFromStage } from "./init";
 import type { RawSession, Session } from "../defs/types";
 
 // actions
@@ -116,7 +116,9 @@ export const setActiveSession = validatedApiDispatcher({
         // passing in null will unset the active session
         if (payload == null) {
             dispatch(setActiveSessionAction(null));
-            return; // TODO: is this return warranted assuming we want to really unset current session? we need to clear state somewhere
+            // TODO: is this return warranted assuming we want to really unset current session? we need to clear state somewhere
+            dispatch(clearSessionDependentData());
+            return; 
         }
         if ((currentActiveSession || { id: null }).id === payload.id) {
             return;

--- a/frontend/src/api/actions/sessions.ts
+++ b/frontend/src/api/actions/sessions.ts
@@ -116,7 +116,7 @@ export const setActiveSession = validatedApiDispatcher({
         // passing in null will unset the active session
         if (payload == null) {
             dispatch(setActiveSessionAction(null));
-            return;
+            return; // TODO: is this return warranted assuming we want to really unset current session? we need to clear state somewhere
         }
         if ((currentActiveSession || { id: null }).id === payload.id) {
             return;

--- a/frontend/src/components/sessions.js
+++ b/frontend/src/components/sessions.js
@@ -5,7 +5,6 @@ import {
     activeSessionSelector,
     upsertSession,
     deleteSession,
-    initFromStage,
     setActiveSession,
 } from "../api/actions";
 import { Alert, Modal, Button } from "react-bootstrap";
@@ -136,10 +135,9 @@ export function ConnectedSessionsList(props) {
                 show={!!sessionToDelete}
                 onHide={() => setSessionToDelete(null)}
                 onDelete={async () => {
-                    await dispatch(setActiveSession(null));
-                    // if (sessionToDelete === activeSession) {
-                    //     await dispatch(initFromStage("setActiveSession"));
-                    // }
+                    if (sessionToDelete === activeSession) {
+                        await dispatch(setActiveSession(null));
+                    }
                     await dispatch(deleteSession(sessionToDelete));
                     setSessionToDelete(null);
                 }}

--- a/frontend/src/components/sessions.js
+++ b/frontend/src/components/sessions.js
@@ -5,12 +5,8 @@ import {
     activeSessionSelector,
     upsertSession,
     deleteSession,
+    initFromStage,
     setActiveSession,
-    fetchApplicantsSuccess,
-    fetchAssignmentsSuccess,
-    fetchContractTemplatesSuccess,
-    fetchApplicationsSuccess,
-    fetchPositionsSuccess,
 } from "../api/actions";
 import { Alert, Modal, Button } from "react-bootstrap";
 import { FaTimes, FaTrash } from "react-icons/fa";
@@ -140,16 +136,10 @@ export function ConnectedSessionsList(props) {
                 show={!!sessionToDelete}
                 onHide={() => setSessionToDelete(null)}
                 onDelete={async () => {
-                    if (sessionToDelete === activeSession) {
-                        await Promise.all([
-                            dispatch(setActiveSession(null)),
-                            dispatch(fetchApplicantsSuccess([])),
-                            dispatch(fetchAssignmentsSuccess([])),
-                            dispatch(fetchContractTemplatesSuccess([])),
-                            dispatch(fetchApplicationsSuccess([])),
-                            dispatch(fetchPositionsSuccess([])),
-                        ]);
-                    }
+                    await dispatch(setActiveSession(null));
+                    // if (sessionToDelete === activeSession) {
+                    //     await dispatch(initFromStage("setActiveSession"));
+                    // }
                     await dispatch(deleteSession(sessionToDelete));
                     setSessionToDelete(null);
                 }}

--- a/frontend/src/components/sessions.js
+++ b/frontend/src/components/sessions.js
@@ -1,6 +1,17 @@
 import React from "react";
 import { useSelector } from "react-redux";
-import { sessionsSelector, upsertSession, deleteSession } from "../api/actions";
+import {
+    sessionsSelector,
+    activeSessionSelector,
+    upsertSession,
+    deleteSession,
+    setActiveSession,
+    fetchApplicantsSuccess,
+    fetchAssignmentsSuccess,
+    fetchContractTemplatesSuccess,
+    fetchApplicationsSuccess,
+    fetchPositionsSuccess,
+} from "../api/actions";
 import { Alert, Modal, Button } from "react-bootstrap";
 import { FaTimes, FaTrash } from "react-icons/fa";
 import { generateHeaderCell } from "./table-utils";
@@ -43,6 +54,7 @@ export function ConnectedSessionsList(props) {
     const { inDeleteMode = false } = props;
     const [sessionToDelete, setSessionToDelete] = React.useState(null);
     const sessions = useSelector(sessionsSelector);
+    const activeSession = useSelector(activeSessionSelector);
     const dispatch = useThunkDispatch();
 
     function _upsertSession(session) {
@@ -128,6 +140,16 @@ export function ConnectedSessionsList(props) {
                 show={!!sessionToDelete}
                 onHide={() => setSessionToDelete(null)}
                 onDelete={async () => {
+                    if (sessionToDelete === activeSession) {
+                        await Promise.all([
+                            dispatch(setActiveSession(null)),
+                            dispatch(fetchApplicantsSuccess([])),
+                            dispatch(fetchAssignmentsSuccess([])),
+                            dispatch(fetchContractTemplatesSuccess([])),
+                            dispatch(fetchApplicationsSuccess([])),
+                            dispatch(fetchPositionsSuccess([])),
+                        ]);
+                    }
                     await dispatch(deleteSession(sessionToDelete));
                     setSessionToDelete(null);
                 }}


### PR DESCRIPTION
Solves #564. We are now falling back to the `null` active session when deleting a currently active session. Additionally, we clear all session-related data. A small refactor so we actually do that on any `setActiveSession(null)` call. Confirmed this should not break anything in other parts of the app.

Visually, as soon as the active session gets deleted, we fall back to the default "unselected" session and the tables UI is cleared of anything related to the deleted session.