### PR TITLE
Make headers sticky for all matrix questions

### DIFF
--- a/frontend/src/views/public/postings/survey.css
+++ b/frontend/src/views/public/postings/survey.css
@@ -12,3 +12,11 @@ the active button to be bright. */
 .sv_main.sv_main .sv-boolean__switch {
     background-color: var(--primary) !important;
 }
+
+.table.sv_q_matrix thead th, .table.sv_q_matrix thead td {
+    position: sticky;
+    top: 0;
+    border-top: 0;
+    z-index: 1;
+    background: white;
+}


### PR DESCRIPTION
Related to #618 For a better UX we need the header with choices of position preferences to be sticky. This behavior will apply to all matrix (tables) questions. Video to show the new behavior:

https://user-images.githubusercontent.com/23097023/125226229-a5d76900-e29e-11eb-9849-9a6449e9d7e1.mp4

