### PR TITLE
Correctly filter assignments/applicants for Instructor view

### DIFF
--- a/backend/app/controllers/api/v1/instructor/assignments_controller.rb
+++ b/backend/app/controllers/api/v1/instructor/assignments_controller.rb
@@ -11,12 +11,8 @@ class Api::V1::Instructor::AssignmentsController < ApplicationController
         active_instructor = Instructor.find_by(utorid: active_user.utorid)
         render_success([]) && return unless active_instructor
 
-        # Find the IDs of all instructors that are associated with the same positions we are
-        position_ids =
-            active_instructor.positions.where(session_id: params[:session_id])
-                .pluck(:id).uniq
-        render_success Assignment.distinct.order(:id).where(
-                           position_id: position_ids
+        render_success active_instructor.assignments_by_session(
+                           params[:session_id]
                        )
     end
 end

--- a/backend/app/controllers/api/v1/instructor/positions_controller.rb
+++ b/backend/app/controllers/api/v1/instructor/positions_controller.rb
@@ -10,8 +10,8 @@ class Api::V1::Instructor::PositionsController < ApplicationController
         active_instructor = Instructor.find_by(utorid: active_user.utorid)
         render_success([]) && return unless active_instructor
 
-        render_success active_instructor.positions.where(
-                           session_id: params[:session_id]
+        render_success active_instructor.positions_by_session(
+                           params[:session_id]
                        )
     end
 end

--- a/backend/app/models/instructor.rb
+++ b/backend/app/models/instructor.rb
@@ -6,6 +6,29 @@ class Instructor < ApplicationRecord
     validates_presence_of :last_name, :first_name, :utorid
     validates_uniqueness_of :utorid
 
+    # Returns all the positions this instructor is assigned to in a given session
+    def positions_by_session(session_id)
+        positions.distinct.where(session: session_id).order(:position_code)
+    end
+
+    # Returns all the assignments for courses this instructor is an instructor for
+    # in the given session. These assignments are limited to ones that have been
+    # Accepted or are Pending; no Rejected/Withdrawn/Preliminary assignments are returned
+    def assignments_by_session(session_id)
+        Assignment.joins(:active_offer, position: :instructors).distinct.order(
+            :id
+        ).where(
+            active_offer: { status: %i[pending accepted] },
+            position: { instructors: id, session: session_id }
+        )
+    end
+
+    # Returns all the applicants associated with the instructor and session
+    def applicants_by_session(session_id)
+        Applicant.distinct.order(:last_name, :first_name).joins(:assignments)
+            .where("assignments.id": assignments_by_session(session_id).ids)
+    end
+
     # Returns a formatted string displaying the instructor's contact information
     def contact_info
         if email?

--- a/frontend/src/tests/instructor-permission-test.js
+++ b/frontend/src/tests/instructor-permission-test.js
@@ -522,7 +522,7 @@ export function instructorsPermissionTests(api) {
             );
             expect(resp).toHaveStatus("success");
 
-            // Only one DDAH is intially seeded for this instructor
+            // Only one DDAH is initially seeded for this instructor
             expect(resp.payload).toHaveLength(1);
 
             // We get duties returned sorted in ascending order, so
@@ -562,16 +562,9 @@ export function instructorsPermissionTests(api) {
         });
 
         it("update a Ddah for an assignment associated with self", async () => {
-            // Fetch the first assignment associated with our instructor
-            let resp = await apiGET(
-                `/instructor/sessions/${session.id}/assignments`
-            );
-            expect(resp).toHaveStatus("success");
-            const assignment_id = resp.payload[0].id;
-
             // Update the DDAH and check it was updated correctly
             const updatedDdah = {
-                assignment_id,
+                assignment_id: assignment.id,
                 duties: [
                     {
                         order: 1,
@@ -585,7 +578,7 @@ export function instructorsPermissionTests(api) {
                     },
                 ],
             };
-            resp = await apiPOST(`/instructor/ddahs`, updatedDdah);
+            let resp = await apiPOST(`/instructor/ddahs`, updatedDdah);
             expect(resp).toHaveStatus("success");
             expect(resp.payload).toEqual(expect.objectContaining(updatedDdah));
         });


### PR DESCRIPTION
An Instructor should only have access to information about applicants that have been assigned to their course. Additionally, they should not have access to the applicant's phone number.