### PR TITLE
Fix race condition in ddahs/assignments selector

### DIFF
--- a/frontend/src/api/actions/ddahs.ts
+++ b/frontend/src/api/actions/ddahs.ts
@@ -260,16 +260,18 @@ export const ddahsSelector = createSelector(
             return [];
         }
         const assignmentsHash = arrayToHash(assignments);
-        return ddahs
-            .map(({ assignment_id, ...rest }) => ({
-                ...rest,
-                status: computeDdahStatus(rest),
-                total_hours: computeDdahHours(rest),
-                assignment: assignmentsHash[assignment_id] || {},
-            }))
-            // If the DDAHs are loaded before the assignments, we may have a mismatch here.
-            // We filter out any ddahs without assignments (they will be updated when
-            // assignments become available.)
-            .filter((ddah) => ddah.assignment.id != null) as Ddah[];
+        return (
+            ddahs
+                .map(({ assignment_id, ...rest }) => ({
+                    ...rest,
+                    status: computeDdahStatus(rest),
+                    total_hours: computeDdahHours(rest),
+                    assignment: assignmentsHash[assignment_id] || {},
+                }))
+                // If the DDAHs are loaded before the assignments, we may have a mismatch here.
+                // We filter out any ddahs without assignments (they will be updated when
+                // assignments become available.)
+                .filter((ddah) => ddah.assignment.id != null) as Ddah[]
+        );
     }
 );

--- a/frontend/src/api/actions/ddahs.ts
+++ b/frontend/src/api/actions/ddahs.ts
@@ -260,11 +260,16 @@ export const ddahsSelector = createSelector(
             return [];
         }
         const assignmentsHash = arrayToHash(assignments);
-        return ddahs.map(({ assignment_id, ...rest }) => ({
-            ...rest,
-            status: computeDdahStatus(rest),
-            total_hours: computeDdahHours(rest),
-            assignment: assignmentsHash[assignment_id] || {},
-        })) as Ddah[];
+        return ddahs
+            .map(({ assignment_id, ...rest }) => ({
+                ...rest,
+                status: computeDdahStatus(rest),
+                total_hours: computeDdahHours(rest),
+                assignment: assignmentsHash[assignment_id] || {},
+            }))
+            // If the DDAHs are loaded before the assignments, we may have a mismatch here.
+            // We filter out any ddahs without assignments (they will be updated when
+            // assignments become available.)
+            .filter((ddah) => ddah.assignment.id != null) as Ddah[];
     }
 );

--- a/frontend/src/components/filter-table/filter-table.css
+++ b/frontend/src/components/filter-table/filter-table.css
@@ -120,6 +120,9 @@
     padding-left: 0px;
     padding-right: 0px;
 }
+.details-col.centered {
+    text-align: center;
+}
 .hidden-row-warning {
     box-shadow: inset 0px -3px 8px -6px rgba(167, 182, 194, 0.5);
     text-align: center;

--- a/frontend/src/libs/ddah-utils.ts
+++ b/frontend/src/libs/ddah-utils.ts
@@ -1,0 +1,58 @@
+import { formatDate } from "./utils";
+import type { Ddah } from "../api/defs/types";
+/**
+ * Determine if there are issues with `ddah` and
+ * return a human-readable string specifying the issues
+ *
+ * @param {Ddah} ddah
+ * @returns
+ */
+export function ddahIssues(ddah: Ddah) {
+    if (ddah.total_hours !== ddah.assignment.hours) {
+        return `Hours Mismatch (${ddah.total_hours} vs. ${ddah.assignment.hours})`;
+    }
+    return null;
+}
+
+/**
+ * Compute a readable status for a DDAH object.
+ *
+ * @export
+ * @param {Pick<Ddah, "status">} ddah
+ * @returns
+ */
+export function getReadableStatus(ddah: Pick<Ddah, "status">) {
+    switch (ddah.status) {
+        case "accepted":
+            return "Accepted";
+        case "emailed":
+            return "Pending";
+        default:
+            return "Unsent";
+    }
+}
+
+/**
+ * Compute the date of the most recent activity for a DDAH object.
+ *
+ * @export
+ * @param {Ddah} ddah
+ * @returns
+ */
+export function getRecentActivityDate(ddah: Ddah) {
+    const recentActivityDate = (Math.max.apply as (...values: any[]) => number)(
+        null,
+        [
+            ddah.accepted_date,
+            ddah.approved_date,
+            ddah.emailed_date,
+            ddah.revised_date,
+        ]
+            .filter((date) => date)
+            .map((date) => new Date(date || 0))
+    );
+    if (recentActivityDate <= 0) {
+        return null;
+    }
+    return formatDate(new Date(recentActivityDate).toISOString());
+}

--- a/frontend/src/views/admin/ddah-table/index.tsx
+++ b/frontend/src/views/admin/ddah-table/index.tsx
@@ -21,6 +21,11 @@ import { DdahEditor } from "../../../components/ddahs";
 import { generateHeaderCell } from "../../../components/table-utils";
 import { AdvancedFilterTable } from "../../../components/filter-table/advanced-filter-table";
 import { useThunkDispatch } from "../../../libs/thunk-dispatch";
+import {
+    ddahIssues,
+    getReadableStatus,
+    getRecentActivityDate,
+} from "./../../../libs/ddah-utils";
 
 export interface RowData {
     id?: number;
@@ -33,49 +38,6 @@ export interface RowData {
     emailed_date: string | null;
     issues: string | null;
     issue_code: "hours_mismatch" | "missing" | null;
-}
-
-/**
- * Determine if there are issues with `ddah` and
- * return a human-readable string specifying the issues
- *
- * @param {Ddah} ddah
- * @returns
- */
-export function ddahIssues(ddah: Ddah) {
-    if (ddah.total_hours !== ddah.assignment.hours) {
-        return `Hours Mismatch (${ddah.total_hours} vs. ${ddah.assignment.hours})`;
-    }
-    return null;
-}
-
-export function getReadableStatus(ddah: Pick<Ddah, "status">) {
-    switch (ddah.status) {
-        case "accepted":
-            return "Accepted";
-        case "emailed":
-            return "Pending";
-        default:
-            return "Unsent";
-    }
-}
-
-function getRecentActivityDate(ddah: Ddah) {
-    const recentActivityDate = (Math.max.apply as (...values: any[]) => number)(
-        null,
-        [
-            ddah.accepted_date,
-            ddah.approved_date,
-            ddah.emailed_date,
-            ddah.revised_date,
-        ]
-            .filter((date) => date)
-            .map((date) => new Date(date || 0))
-    );
-    if (recentActivityDate <= 0) {
-        return null;
-    }
-    return formatDate(new Date(recentActivityDate).toISOString());
 }
 
 /**
@@ -382,21 +344,6 @@ export function ConnectedDdahsTable() {
     const [previewVisible, setPreviewVisible] = React.useState<Boolean>(false);
     const [editVisible, setEditVisible] = React.useState<Boolean>(false);
     const [previewDdah, setPreviewDdah] = React.useState<Ddah | null>(null);
-
-    // It is possible that things needed to construct the DDAH are loaded out of order.
-    // E.g., the position or assignment data hasn't come back from the API
-    // even though the DDAH data has. In this case, we want to fail gracefully until
-    // the data arrives (by showing an empty list of DDAHs).
-    if (
-        ddahs.some(
-            (ddah) =>
-                ddah.assignment == null ||
-                ddah.assignment.applicant == null ||
-                ddah.assignment.position == null
-        )
-    ) {
-        ddahs = [];
-    }
 
     function setSelected(ids: number[]) {
         // If a row is missing an id, `null` will be used in place of that id.

--- a/frontend/src/views/admin/ddahs/ddah-confirmation-dialog.tsx
+++ b/frontend/src/views/admin/ddahs/ddah-confirmation-dialog.tsx
@@ -1,10 +1,10 @@
 import { Button, Modal } from "react-bootstrap";
 import React from "react";
-import { ddahIssues, getReadableStatus } from "../ddah-table";
 import { AdvancedFilterTable } from "../../../components/filter-table/advanced-filter-table";
 import { Ddah } from "../../../api/defs/types";
 import { compareString } from "../../../libs/utils";
 import { generateHeaderCell } from "../../../components/table-utils";
+import { ddahIssues, getReadableStatus } from "../../../libs/ddah-utils";
 
 const ddahModalColumn = [
     {

--- a/frontend/src/views/instructor/routes/index.tsx
+++ b/frontend/src/views/instructor/routes/index.tsx
@@ -3,7 +3,7 @@ import { Redirect, Route, Switch } from "react-router-dom";
 import { InstructorPositionsView } from "../positions";
 import { InstructorAssignmentsView } from "../assignments";
 import { Landing as InstructorLanding } from "../landing";
-import { InstructorDdahsView } from "../ddahs";
+//import { InstructorDdahsView } from "../ddahs";
 
 export function InstructorRoutes() {
     return (
@@ -21,7 +21,10 @@ export function InstructorRoutes() {
                 <InstructorAssignmentsView />
             </Route>
             <Route exact path="/tapp/ddahs">
-                <InstructorDdahsView />
+                {
+                    //<InstructorDdahsView />
+                }
+                Not Implemented
             </Route>
         </Switch>
     );

--- a/frontend/src/views/instructor/routes/index.tsx
+++ b/frontend/src/views/instructor/routes/index.tsx
@@ -3,6 +3,7 @@ import { Redirect, Route, Switch } from "react-router-dom";
 import { InstructorPositionsView } from "../positions";
 import { InstructorAssignmentsView } from "../assignments";
 import { Landing as InstructorLanding } from "../landing";
+import { InstructorDdahsView } from "../ddahs";
 
 export function InstructorRoutes() {
     return (
@@ -20,7 +21,7 @@ export function InstructorRoutes() {
                 <InstructorAssignmentsView />
             </Route>
             <Route exact path="/tapp/ddahs">
-                <div>Not implemented yet</div>
+                <InstructorDdahsView />
             </Route>
         </Switch>
     );


### PR DESCRIPTION
If Ddahs or Assignments were loaded before the data they depend on is
loaded, they may be improperly constructored (with empty objects
standing in for the referenced assignment/position/applicant). This
update ensure that improperly constructed data is filterd out.