### PR TITLE
Add TAs table to the instructor view.

### DIFF
--- a/frontend/src/libs/ddah-utils.ts
+++ b/frontend/src/libs/ddah-utils.ts
@@ -21,7 +21,7 @@ export function ddahIssues(ddah: Ddah) {
  * @param {Pick<Ddah, "status">} ddah
  * @returns
  */
-export function getReadableStatus(ddah: Pick<Ddah, "status">) {
+export function getReadableDDAHStatus(ddah: Pick<Ddah, "status">) {
     switch (ddah.status) {
         case "accepted":
             return "Accepted";

--- a/frontend/src/libs/utils.ts
+++ b/frontend/src/libs/utils.ts
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallowEqual } from "react-redux";
-import { Session } from "../api/defs/types";
+import { Assignment, Session } from "../api/defs/types";
 
 /**
  * Compare the two input strings.
@@ -186,4 +186,14 @@ export function guessActiveSession(sessions: Session[]): Session | null {
     }
 
     return null;
+}
+
+export function getReadableAssignmentStatus(assignment: Pick<Assignment, "active_offer_status">) {
+    // TODO: confirm wording to be easier for the instructor
+    switch (assignment.active_offer_status) {
+        case "accepted":
+            return "Assigned";
+        default:
+            return capitalize(assignment.active_offer_status);
+    }
 }

--- a/frontend/src/views/admin/ddah-table/index.tsx
+++ b/frontend/src/views/admin/ddah-table/index.tsx
@@ -19,7 +19,7 @@ import { AdvancedFilterTable } from "../../../components/filter-table/advanced-f
 import { useThunkDispatch } from "../../../libs/thunk-dispatch";
 import {
     ddahIssues,
-    getReadableStatus,
+    getReadableDDAHStatus,
     getRecentActivityDate,
     splitDutyDescription,
 } from "./../../../libs/ddah-utils";
@@ -56,7 +56,7 @@ export function StatusCell({
     if (original.id == null) {
         return null as any;
     }
-    const readableStatus = getReadableStatus(original as Pick<Ddah, "status">);
+    const readableStatus = getReadableDDAHStatus(original as Pick<Ddah, "status">);
     switch ((original as Pick<Ddah, "status">).status) {
         case "accepted":
             return (
@@ -377,7 +377,7 @@ export function ConnectedDdahsTable() {
                 recent_activity_date: getRecentActivityDate(ddah),
                 emailed_date: formatDate(ddah.emailed_date || ""),
                 approved: ddah.approved_date ? "Approved" : "",
-                readable_status: getReadableStatus(ddah),
+                readable_status: getReadableDDAHStatus(ddah),
                 issues: ddahIssues(ddah),
                 issue_code: ddahIssues(ddah) ? "hours_mismatch" : null,
             } as RowData)

--- a/frontend/src/views/admin/ddahs/ddah-confirmation-dialog.tsx
+++ b/frontend/src/views/admin/ddahs/ddah-confirmation-dialog.tsx
@@ -4,7 +4,7 @@ import { AdvancedFilterTable } from "../../../components/filter-table/advanced-f
 import { Ddah } from "../../../api/defs/types";
 import { compareString } from "../../../libs/utils";
 import { generateHeaderCell } from "../../../components/table-utils";
-import { ddahIssues, getReadableStatus } from "../../../libs/ddah-utils";
+import { ddahIssues, getReadableDDAHStatus } from "../../../libs/ddah-utils";
 
 const ddahModalColumn = [
     {
@@ -84,7 +84,7 @@ export function DdahConfirmationDialog(props: {
             last_name: ddah.assignment.applicant.last_name,
             first_name: ddah.assignment.applicant.first_name,
             total_hours: ddah.total_hours,
-            status: getReadableStatus(ddah),
+            status: getReadableDDAHStatus(ddah),
             issue: ddahIssue,
         } as ConfirmationDdahRowData;
     });

--- a/frontend/src/views/instructor/assignments/index.tsx
+++ b/frontend/src/views/instructor/assignments/index.tsx
@@ -1,10 +1,23 @@
 import React from "react";
-import { ConnectedOfferTable } from "../../admin/offertable";
+import { ConnectedTAsTable } from "./tas-table";
 import { ConnectedExportAssignmentsAction } from "../../admin/assignments/import-export";
 import { ActionsList, ActionHeader } from "../../../components/action-buttons";
 import { ContentArea } from "../../../components/layout";
+import { useSelector } from "react-redux";
+import { activeSessionSelector, assignmentsSelector } from "../../../api/actions";
+import { ddahsSelector } from "../../../api/actions/ddahs";
+import { Ddah } from "../../../api/defs/types";
+import { MissingActiveSessionWarning } from "../../../components/sessions";
+import { useThunkDispatch } from "../../../libs/thunk-dispatch";
+import { activePositionSelector } from "../store/actions";
 
 export function InstructorAssignmentsView() {
+    const activeSession = useSelector(activeSessionSelector);
+    const ddahs = useSelector(ddahsSelector);
+    const assignments = useSelector(assignmentsSelector);
+    const dispatch = useThunkDispatch();
+    const activePosition = useSelector(activePositionSelector);
+
     return (
         <div className="page-body">
             <ActionsList>
@@ -12,7 +25,13 @@ export function InstructorAssignmentsView() {
                 <ConnectedExportAssignmentsAction />
             </ActionsList>
             <ContentArea>
-                <ConnectedOfferTable editable={false} />
+                {activeSession ? null : (
+                    <MissingActiveSessionWarning extraText="To view or modify DDAHs, you must select a session." />
+                )}
+                <ConnectedTAsTable
+                    position_id={activePosition?.id || -1}
+                    onView={f => f}
+                />
             </ContentArea>
         </div>
     );

--- a/frontend/src/views/instructor/assignments/tas-table.tsx
+++ b/frontend/src/views/instructor/assignments/tas-table.tsx
@@ -32,10 +32,12 @@ export interface RowData {
  */
 export function ConnectedTAsTable({
     position_id,
-    onView,
+    onViewDDAH,
+    onCreateDDAH,
 }: {
     position_id: number;
-    onView?: (ddah_id: number) => any;
+    onViewDDAH?: (ddah: Ddah | null) => any;
+    onCreateDDAH?: (assignment_id: number) => any;
 }) {
     const allAssignments = useSelector(assignmentsSelector);
     const allDdahs = useSelector(ddahsSelector);
@@ -51,7 +53,6 @@ export function ConnectedTAsTable({
     const data = assignments.map((assignment) => {
         const ddah =
             ddahs.find((ddah) => ddah.assignment.id === assignment.id) || null;
-            console.log(ddah);
         return {
             id: assignment.id,
             last_name: assignment.applicant.last_name,
@@ -71,8 +72,8 @@ export function ConnectedTAsTable({
         row: { original: RowData };
     }): JSX.Element | null {
         const original = row.original;
-        if (original.id != null) {
-            const ddah_id = original.id;
+        if (original.ddah != null) {
+            const ddah = original.ddah;
             // We are a real DDAH, so we want to view
             return (
                 <Button
@@ -81,8 +82,8 @@ export function ConnectedTAsTable({
                     title={`View or Edit DDAH for ${original.first_name} ${original.last_name}`}
                     className="py-0"
                     onClick={() => {
-                        if (onView) {
-                            onView(ddah_id);
+                        if (onViewDDAH) {
+                            onViewDDAH(ddah);
                         }
                     }}
                 >
@@ -90,7 +91,21 @@ export function ConnectedTAsTable({
                 </Button>
             );
         }
-        return null;
+        return (
+            <Button
+                variant="light"
+                size="sm"
+                title={`Create DDAH for ${original.first_name} ${original.last_name}`}
+                className="py-0"
+                onClick={() => {
+                    if (onCreateDDAH) {
+                        onCreateDDAH(original.id || -1);
+                    }
+                }}
+            >
+                Create
+            </Button>
+        );
     }
 
     const columns = [
@@ -106,7 +121,7 @@ export function ConnectedTAsTable({
         },
         {
             Header: generateHeaderCell("Status"),
-            accessor: "status",
+            accessor: "readable_status",
         },
         {
             Header: generateHeaderCell("DDAH"),

--- a/frontend/src/views/instructor/assignments/tas-table.tsx
+++ b/frontend/src/views/instructor/assignments/tas-table.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { Button } from "react-bootstrap";
+import { useSelector } from "react-redux";
+import { assignmentsSelector } from "../../../api/actions";
+import { ddahsSelector } from "../../../api/actions/ddahs";
+import { Ddah } from "../../../api/defs/types";
+import { AdvancedFilterTable } from "../../../components/filter-table/advanced-filter-table";
+import { generateHeaderCell } from "../../../components/table-utils";
+import { getReadableAssignmentStatus } from "../../../libs/utils";
+
+export interface RowData {
+    id?: number;
+    last_name: string;
+    first_name: string;
+    email: string | null;
+    utorid: string | null;
+    hours: number | null;
+    status: string | null;
+    ddah: Ddah | null;
+}
+
+/**
+ * Table that displays TA information for TAs associated with a single position.
+ *
+ * @export
+ * @param {{
+ *     position_id: number;
+ * }} {
+ *     position_id,
+ * }
+ * @returns
+ */
+export function ConnectedTAsTable({
+    position_id,
+    onView,
+}: {
+    position_id: number;
+    onView?: (ddah_id: number) => any;
+}) {
+    const allAssignments = useSelector(assignmentsSelector);
+    const allDdahs = useSelector(ddahsSelector);
+    let ddahs = allDdahs.filter(
+        (ddah) => ddah.assignment.position.id === position_id
+    );
+    const assignments = allAssignments.filter(
+        (assignment) => assignment.position.id === position_id
+    );
+
+    // The omni-search doesn't work on nested properties, so we need to flatten
+    // the data we display before sending it to the table.
+    const data = assignments.map((assignment) => {
+        const ddah =
+            ddahs.find((ddah) => ddah.assignment.id === assignment.id) || null;
+            console.log(ddah);
+        return {
+            id: assignment.id,
+            last_name: assignment.applicant.last_name,
+            first_name: assignment.applicant.first_name,
+            email: assignment.applicant.email,
+            utorid: assignment.applicant.utorid,
+            hours: ddah?.total_hours,
+            status: assignment.active_offer_status,
+            readable_status: getReadableAssignmentStatus(assignment),
+            ddah: ddah,
+        } as RowData;
+    });
+
+    function ViewOrCreateDDAHCell({
+        row,
+    }: {
+        row: { original: RowData };
+    }): JSX.Element | null {
+        const original = row.original;
+        if (original.id != null) {
+            const ddah_id = original.id;
+            // We are a real DDAH, so we want to view
+            return (
+                <Button
+                    variant="light"
+                    size="sm"
+                    title={`View or Edit DDAH for ${original.first_name} ${original.last_name}`}
+                    className="py-0"
+                    onClick={() => {
+                        if (onView) {
+                            onView(ddah_id);
+                        }
+                    }}
+                >
+                    View
+                </Button>
+            );
+        }
+        return null;
+    }
+
+    const columns = [
+        { Header: generateHeaderCell("Last Name"), accessor: "last_name" },
+        { Header: generateHeaderCell("First Name"), accessor: "first_name" },
+        { Header: generateHeaderCell("Email"), accessor: "email" },
+        { Header: generateHeaderCell("UTORid"), accessor: "utorid" },
+        {
+            Header: generateHeaderCell("DDAH Hours"),
+            accessor: "hours",
+            maxWidth: 120,
+            style: { textAlign: "right" },
+        },
+        {
+            Header: generateHeaderCell("Status"),
+            accessor: "status",
+        },
+        {
+            Header: generateHeaderCell("DDAH"),
+            Cell: ViewOrCreateDDAHCell,
+            id: "add_or_edit",
+            resizable: false,
+            className: "details-col",
+        },
+    ];
+
+    return (
+        <AdvancedFilterTable columns={columns} data={data} filterable={true} />
+    );
+}

--- a/frontend/src/views/instructor/ddahs/ddahs-table.tsx
+++ b/frontend/src/views/instructor/ddahs/ddahs-table.tsx
@@ -6,7 +6,7 @@ import { assignmentsSelector } from "../../../api/actions";
 import { ddahsSelector } from "../../../api/actions/ddahs";
 import { AdvancedFilterTable } from "../../../components/filter-table/advanced-filter-table";
 import { generateHeaderCell } from "../../../components/table-utils";
-import { ddahIssues, getReadableStatus } from "../../../libs/ddah-utils";
+import { ddahIssues, getReadableDDAHStatus } from "../../../libs/ddah-utils";
 import { formatDate } from "../../../libs/utils";
 
 export interface RowData {
@@ -87,7 +87,7 @@ export function ConnectedDdahsTable({
                 status: ddah.status || "unsent",
                 emailed_date: formatDate(ddah.emailed_date || ""),
                 approved: ddah.approved_date ? "Approved" : "",
-                readable_status: getReadableStatus(ddah),
+                readable_status: getReadableDDAHStatus(ddah),
                 issues: ddahIssues(ddah),
                 issue_code: ddahIssues(ddah) ? "hours_mismatch" : null,
             } as RowData)


### PR DESCRIPTION
Add TA Information table to the instructors view consisting of (as per wiki [here](https://github.com/uoft-tapp/tapp/wiki/Instructor-view)) all necessary fields. Add the ability to view and create DDAHs directly from this view (same as in the DDAH table view). The TAs are filtered by position:

![image](https://user-images.githubusercontent.com/23097023/127998689-cc046a70-1382-4fa3-8423-94460d063caa.png)
