### PR TITLE
Do not include hours for notes.

### DIFF
--- a/frontend/src/tests/ddah-tests.js
+++ b/frontend/src/tests/ddah-tests.js
@@ -547,7 +547,7 @@ export function ddahsEmailAndDownloadTests(api) {
                 },
                 {
                     order: 5,
-                    hours: 18,
+                    hours: 0,
                     description: "note:Unique description - note",
                 },
                 {


### PR DESCRIPTION
Test data has a DDAH with hours > 0 for a `notes:` description, but in reality no hours can be assigned for notes.

Closing #648 - test data should not be inconsistent by providing `hours` for notes, but no safeguard is needed on the back-end. The UI should not allow that to happen anyway.