### PR TITLE
Add columns to the TA Information table

### DIFF
--- a/backend/app/controllers/api/v1/instructor/ddahs_controller.rb
+++ b/backend/app/controllers/api/v1/instructor/ddahs_controller.rb
@@ -74,7 +74,7 @@ class Api::V1::Instructor::DdahsController < ApplicationController
 
         # look up the DDAH first by assignment ID, otherwise, create a new DDAH
         if params[:assignment_id]
-            assignment = Assignment.find_by(id: params[:assignment_id])
+            assignment = Assignment.find_by!(id: params[:assignment_id])
             if assignment.accessible_by_instructor(@active_instructor.id)
                 @ddah = assignment.ddah || Ddah.new(ddah_params)
             end

--- a/frontend/src/views/instructor/assignments/assignments-table.tsx
+++ b/frontend/src/views/instructor/assignments/assignments-table.tsx
@@ -6,17 +6,26 @@ import { formatDate } from "../../../libs/utils";
 import { assignmentsSelector } from "../../../api/actions";
 import { AdvancedFilterTable } from "../../../components/filter-table/advanced-filter-table";
 import { Assignment } from "../../../api/defs/types";
+import { ddahsSelector } from "../../../api/actions/ddahs";
 
 export function InstructorAssignmentsTable() {
     const activePosition = useSelector(activePositionSelector);
     const allAssignments = useSelector(assignmentsSelector);
-    const positions = useMemo(
-        () =>
-            allAssignments.filter(
-                (assignment) => assignment.position.id === activePosition?.id
-            ),
-        [activePosition, allAssignments]
-    );
+    const allDDAHs = useSelector(ddahsSelector);
+    const rowData = useMemo(() => {
+        const currentAssignments = allAssignments.filter(
+            (assignment) => assignment.position.id === activePosition?.id
+        );
+
+        const assignmentsWithDDAH = currentAssignments.map((assignment) => ({
+            ...assignment,
+            ddah:
+                allDDAHs.find((ddah) => ddah.assignment.id === assignment.id) ||
+                null,
+        }));
+
+        return assignmentsWithDDAH;
+    }, [activePosition, allAssignments, allDDAHs]);
 
     if (!activePosition) {
         return <h4>No position currently selected</h4>;
@@ -30,6 +39,10 @@ export function InstructorAssignmentsTable() {
         {
             Header: "First Name",
             accessor: "applicant.first_name",
+        },
+        {
+            Header: "UTORid",
+            accessor: "applicant.utorid",
         },
         {
             Header: "Email",
@@ -84,7 +97,7 @@ export function InstructorAssignmentsTable() {
         <AdvancedFilterTable
             filterable={true}
             columns={columns}
-            data={positions}
+            data={rowData}
         />
     );
 }

--- a/frontend/src/views/instructor/assignments/index.tsx
+++ b/frontend/src/views/instructor/assignments/index.tsx
@@ -4,13 +4,53 @@ import { ContentArea } from "../../../components/layout";
 import { InstructorAssignmentsTable } from "./assignments-table";
 import { useSelector } from "react-redux";
 import { activePositionSelector } from "../store/actions";
-import { activeSessionSelector } from "../../../api/actions";
+import { activeSessionSelector, assignmentsSelector } from "../../../api/actions";
 import { formatDate } from "../../../libs/utils";
 import { ConnectedExportAssignmentsAction } from "./import-export";
+import { ddahsSelector, upsertDdah } from "../../../api/actions/ddahs";
+import { Ddah } from "../../../api/defs/types";
+import { useThunkDispatch } from "../../../libs/thunk-dispatch";
+import { DdahPreviewModal } from "../ddahs/ddah-editor";
+import { DdahEmailModal } from "../ddahs/ddah-emailer";
 
 export function InstructorAssignmentsView() {
     const activeSession = useSelector(activeSessionSelector);
     const activePosition = useSelector(activePositionSelector);
+    const ddahs = useSelector(ddahsSelector);
+    const assignments = useSelector(assignmentsSelector);
+    const dispatch = useThunkDispatch();
+
+    const [previewVisible, setPreviewVisible] = React.useState<Boolean>(false);
+    const [newDialogVisible, setNewDialogVisible] = React.useState<Boolean>(
+        false
+    );
+    const [_previewDdah, _setPreviewDdah] = React.useState<Omit<
+        Ddah,
+        "id"
+    > | null>(null);
+    const [previewDdahId, setPreviewDdahId] = React.useState<number | null>(
+        null
+    );
+    const [emailDialogVisible, setEmailDialogVisible] = React.useState(false);
+
+    const setPreviewDdah = React.useCallback(
+        (ddah: Omit<Ddah, "id">) => {
+            const ddahId = (ddah as any)?.id;
+            setPreviewDdahId(ddahId || null);
+
+            _setPreviewDdah(ddah);
+        },
+        [setPreviewDdahId, _setPreviewDdah]
+    );
+
+    const previewDdah: Omit<Ddah, "id"> | null = React.useMemo(() => {
+        if (previewDdahId) {
+            return (
+                ddahs.find((ddah) => ddah.id === previewDdahId) || _previewDdah
+            );
+        }
+        return _previewDdah;
+    }, [ddahs, _previewDdah, previewDdahId]);
 
     if (!activeSession || !activePosition) {
         return (
@@ -50,7 +90,69 @@ export function InstructorAssignmentsView() {
                     have rejected an offer or had their offer withdrawn will now
                     show up.
                 </p>
-                <InstructorAssignmentsTable />
+                <InstructorAssignmentsTable
+                    position_id={activePosition?.id || -1}
+                    onView={(ddah_id) => {
+                        const ddah = ddahs.find((d) => d.id === ddah_id);
+                        if (ddah) {
+                            setPreviewDdah(ddah);
+                            setPreviewVisible(true);
+                        }
+                    }}
+                    onCreate={(assignment_id) => {
+                        const assignment = assignments.find(
+                            (a) => a.id === assignment_id
+                        );
+                        if (!assignment) {
+                            console.warn(
+                                "Could not find assignment with id",
+                                assignment_id
+                            );
+                            return;
+                        }
+                        const newDdah: Omit<Ddah, "id"> = {
+                            duties: [],
+                            approved_date: null,
+                            accepted_date: null,
+                            revised_date: null,
+                            emailed_date: null,
+                            signature: null,
+                            url_token: "",
+                            total_hours: 0,
+                            assignment,
+                            status: null,
+                        };
+                        setPreviewDdah(newDdah);
+                        setNewDialogVisible(true);
+                    }}
+                    onEmail={() => setEmailDialogVisible(true)}
+                />
+                <DdahPreviewModal
+                    ddah={previewDdah}
+                    show={previewVisible}
+                    onHide={() => setPreviewVisible(false)}
+                    onEdit={async (newDdah: Ddah) => {
+                        await dispatch(upsertDdah(newDdah));
+                    }}
+                />
+                <DdahPreviewModal
+                    ddah={previewDdah}
+                    show={newDialogVisible}
+                    forceEditMode={true}
+                    onHide={() => setNewDialogVisible(false)}
+                    onEdit={async (newDdah: Ddah) => {
+                        const returnedDdah = await dispatch(
+                            upsertDdah(newDdah)
+                        );
+                        setPreviewDdahId(returnedDdah.id);
+                        setNewDialogVisible(false);
+                        setPreviewVisible(true);
+                    }}
+                />
+                <DdahEmailModal
+                    show={emailDialogVisible}
+                    onHide={() => setEmailDialogVisible(false)}
+                />
             </ContentArea>
         </div>
     );

--- a/frontend/src/views/instructor/assignments/index.tsx
+++ b/frontend/src/views/instructor/assignments/index.tsx
@@ -4,7 +4,10 @@ import { ContentArea } from "../../../components/layout";
 import { InstructorAssignmentsTable } from "./assignments-table";
 import { useSelector } from "react-redux";
 import { activePositionSelector } from "../store/actions";
-import { activeSessionSelector, assignmentsSelector } from "../../../api/actions";
+import {
+    activeSessionSelector,
+    assignmentsSelector,
+} from "../../../api/actions";
 import { formatDate } from "../../../libs/utils";
 import { ConnectedExportAssignmentsAction } from "./import-export";
 import { ddahsSelector, upsertDdah } from "../../../api/actions/ddahs";


### PR DESCRIPTION
This PR adds UTORid and DDAH columns to the TA Information table. The DDAH column has buttons to either Create or View existing DDAH through the modals that are the same for the DDAH table too.

https://user-images.githubusercontent.com/23097023/129055078-277e0b6c-e2f7-48f8-a94b-dac09ceda7ea.mp4


In the future, it would be nice to put the modal-related logic in Redux store and put the modals in the root of the page. This way we could display them from anywhere. This would allow us to package this modal display with the view/edit cell component and reduce repetition and complexity.