### PR TITLE
Instructor view: render comprehensible changes to the DDAHs on import

### DIFF
--- a/frontend/src/components/import-button.js
+++ b/frontend/src/components/import-button.js
@@ -53,7 +53,7 @@ export function ImportDialog({
 
     const withFileContentsReset = (actionHandler) => () => {
         setFileContents(null);
-        setFileArrayBuffer(null)
+        setFileArrayBuffer(null);
         actionHandler();
     };
 

--- a/frontend/src/components/import-button.js
+++ b/frontend/src/components/import-button.js
@@ -53,6 +53,7 @@ export function ImportDialog({
 
     const withFileContentsReset = (actionHandler) => () => {
         setFileContents(null);
+        setFileArrayBuffer(null)
         actionHandler();
     };
 
@@ -184,7 +185,7 @@ export function ImportDialog({
             <Modal.Footer>
                 <Button
                     variant="secondary"
-                    onClick={withFileContentsReset(withLabelReset(onCancel))}
+                    onClick={withLabelReset(withFileContentsReset(onCancel))}
                 >
                     Cancel
                 </Button>

--- a/frontend/src/components/import-button.js
+++ b/frontend/src/components/import-button.js
@@ -49,12 +49,12 @@ export function ImportDialog({
     const withLabelReset = (actionHandler) => () => {
         setFileInputLabel(DEFAULT_LABEL);
         actionHandler();
-    }
+    };
 
     const withFileContentsReset = (actionHandler) => () => {
         setFileContents(null);
         actionHandler();
-    }
+    };
 
     // When we are processing we want to set a spinner button
     // in the dialog as well as communicate to our parent
@@ -182,7 +182,10 @@ export function ImportDialog({
             </Modal.Body>
 
             <Modal.Footer>
-                <Button variant="secondary" onClick={withFileContentsReset(withLabelReset(onCancel))}>
+                <Button
+                    variant="secondary"
+                    onClick={withFileContentsReset(withLabelReset(onCancel))}
+                >
                     Cancel
                 </Button>
                 <Button variant="primary" onClick={_onConfirm}>

--- a/frontend/src/components/import-button.js
+++ b/frontend/src/components/import-button.js
@@ -46,8 +46,13 @@ export function ImportDialog({
 
     let formElement = null;
 
-    const withLabelReset = (actionHandler) => async () => {
+    const withLabelReset = (actionHandler) => () => {
         setFileInputLabel(DEFAULT_LABEL);
+        actionHandler();
+    }
+
+    const withFileContentsReset = (actionHandler) => () => {
+        setFileContents(null);
         actionHandler();
     }
 
@@ -177,7 +182,7 @@ export function ImportDialog({
             </Modal.Body>
 
             <Modal.Footer>
-                <Button variant="secondary" onClick={withLabelReset(onCancel)}>
+                <Button variant="secondary" onClick={withFileContentsReset(withLabelReset(onCancel))}>
                     Cancel
                 </Button>
                 <Button variant="primary" onClick={_onConfirm}>

--- a/frontend/src/components/import-button.js
+++ b/frontend/src/components/import-button.js
@@ -44,6 +44,13 @@ export function ImportDialog({
     const [fileContents, setFileContents] = React.useState(null);
     const [inProgress, _setInProgress] = React.useState(false);
 
+    let formElement = null;
+
+    const withLabelReset = (actionHandler) => async () => {
+        setFileInputLabel(DEFAULT_LABEL);
+        actionHandler();
+    }
+
     // When we are processing we want to set a spinner button
     // in the dialog as well as communicate to our parent
     // that we are in the midst of processing. Therefore, we
@@ -68,7 +75,7 @@ export function ImportDialog({
         if (onFileChange instanceof Function) {
             onFileChange(fileContents);
         }
-    }, [fileContents, onFileChange]);
+    }, [fileContents, onFileChange, formElement]);
 
     // Wrap the <input type="file" /> in an effect that parses the file
     React.useEffect(() => {
@@ -170,7 +177,7 @@ export function ImportDialog({
             </Modal.Body>
 
             <Modal.Footer>
-                <Button variant="secondary" onClick={onCancel}>
+                <Button variant="secondary" onClick={withLabelReset(onCancel)}>
                     Cancel
                 </Button>
                 <Button variant="primary" onClick={_onConfirm}>

--- a/frontend/src/views/admin/ddahs/import-export.tsx
+++ b/frontend/src/views/admin/ddahs/import-export.tsx
@@ -353,8 +353,7 @@ const DialogContent = React.memo(function DialogContent({
         if (newItems.length === 0 && modifiedDiffSpec.length === 0) {
             dialogContent = (
                 <Alert variant="warning">
-                    No difference between imported applicants and those already
-                    on the system.
+                    No difference between imported and existing DDAHs.
                 </Alert>
             );
         } else {

--- a/frontend/src/views/instructor/ddahs/import.tsx
+++ b/frontend/src/views/instructor/ddahs/import.tsx
@@ -48,7 +48,7 @@ function getDutiesDiff(oldDuties: RawDuty[], newDuties: RawDuty[]): DutyDiff[] {
                 oldDuty.description === newDuty.description &&
                 oldDuty.hours === newDuty.hours
             ) {
-                changes.push({ oldDuty, newDuty, status: DiffType.Unchanged });
+                changes.push({ oldDuty, status: DiffType.Unchanged });
                 newDuties.splice(index, 1);
                 oldDutyDeleted = false;
             } else if (

--- a/frontend/src/views/instructor/ddahs/import.tsx
+++ b/frontend/src/views/instructor/ddahs/import.tsx
@@ -123,13 +123,13 @@ function dutiesDiffList(changes: DutyDiff[]) {
 function DdahsList({ ddahs }: { ddahs: Omit<Ddah, "id">[] }) {
     return (
         <ul>
-            {ddahs.map(({ assignment: { applicant }, duties }) => (
+            {ddahs.map(({ assignment: { applicant }, duties }, i) => (
                 <li>
                     DDAH for {applicant.first_name} {applicant.last_name} (
                     {applicant.utorid})
-                    <ul>
+                    <ul className="instructor-ddah-import-new-ddah-duties-list">
                         {duties.map((duty) => (
-                            <li>
+                            <li key={`ddah-new-${i}`}>
                                 {duty.description} - {duty.hours}h
                             </li>
                         ))}
@@ -143,7 +143,7 @@ function DdahsList({ ddahs }: { ddahs: Omit<Ddah, "id">[] }) {
 function DdahsDiffList({ ddahUpdates }: { ddahUpdates: DdahUpdate[] }) {
     return (
         <ul className="instructor-ddah-import-duties-diff-list">
-            {ddahUpdates.map(({ oldDdah, updatedDdah }) => {
+            {ddahUpdates.map(({ oldDdah, updatedDdah }, i) => {
                 const dutiesDiff = getDutiesDiff(
                     oldDdah.duties,
                     updatedDdah.duties
@@ -154,7 +154,7 @@ function DdahsDiffList({ ddahUpdates }: { ddahUpdates: DdahUpdate[] }) {
                     },
                 } = updatedDdah;
                 return (
-                    <li>
+                    <li key={`ddah-diff-${i}`}>
                         DDAH for {first_name} {last_name} ({utorid})
                         {dutiesDiffList(dutiesDiff)}
                     </li>
@@ -285,7 +285,6 @@ const DialogContent = React.memo(function DialogContent({
     }
 
     if (!fileLoaded) {
-        console.log("Clear!");
         return <p>No data loaded.</p>;
     }
 

--- a/frontend/src/views/instructor/ddahs/import.tsx
+++ b/frontend/src/views/instructor/ddahs/import.tsx
@@ -40,10 +40,10 @@ function getDutiesDiff(oldDuties: RawDuty[], newDuties: RawDuty[]): DutyDiff[] {
     let changes: DutyDiff[] = [];
     let dutiesChanged = false;
 
-    oldDuties.forEach((oldDuty) => {
+    for (const oldDuty of oldDuties) {
         let oldDutyDeleted = true;
 
-        newDuties.forEach((newDuty, index) => {
+        for (const [index, newDuty] of newDuties.entries()) {
             if (
                 oldDuty.description === newDuty.description &&
                 oldDuty.hours === newDuty.hours
@@ -60,59 +60,62 @@ function getDutiesDiff(oldDuties: RawDuty[], newDuties: RawDuty[]): DutyDiff[] {
                 oldDutyDeleted = false;
                 dutiesChanged = true;
             }
-        });
+        }
 
         // If we did not find old duties to match the new one - mark it as created
         if (oldDutyDeleted) {
             changes.push({ oldDuty, status: DiffType.Deleted });
             dutiesChanged = true;
         }
-    });
+    }
 
     // The new duties that are left were just created - add them
-    newDuties.forEach((duty) =>
-        changes.push({ newDuty: duty, status: DiffType.Created })
+    changes = changes.concat(
+        newDuties.map((duty) => ({ newDuty: duty, status: DiffType.Created }))
     );
 
     // Do not return changes if everything is unchanged
     return dutiesChanged ? changes : [];
 }
 
+function DutyItem({ oldDuty, newDuty, status }: DutyDiff) {
+    switch (status) {
+        case DiffType.Unchanged:
+            return (
+                <li className="duty-unchanged">
+                    {oldDuty!.description} - {oldDuty!.hours}h
+                </li>
+            );
+        case DiffType.Updated:
+            return (
+                <li className="duty-updated">
+                    {oldDuty!.description} - {oldDuty!.hours}h{" ➞ "}
+                    {newDuty!.hours}h
+                </li>
+            );
+        case DiffType.Created:
+            return (
+                <li className="duty-created">
+                    {newDuty!.description} - {newDuty!.hours}h
+                </li>
+            );
+        case DiffType.Deleted:
+            return (
+                <li className="duty-deleted">
+                    {oldDuty!.description} - {oldDuty!.hours}h
+                </li>
+            );
+        default:
+            return null as never;
+    }
+}
+
 function DutiesDiffList({ changes }: { changes: DutyDiff[] }) {
     return (
         <ul>
-            {changes.map(({ oldDuty, newDuty, status }) => {
-                switch (status) {
-                    case DiffType.Unchanged:
-                        return (
-                            <li className="duty-unchanged">
-                                {oldDuty!.description} - {oldDuty!.hours}h
-                            </li>
-                        );
-                    case DiffType.Updated:
-                        return (
-                            <li className="duty-updated">
-                                {oldDuty!.description} - {oldDuty!.hours}h
-                                {" ➞ "}
-                                {newDuty!.hours}h
-                            </li>
-                        );
-                    case DiffType.Created:
-                        return (
-                            <li className="duty-created">
-                                {newDuty!.description} - {newDuty!.hours}h
-                            </li>
-                        );
-                    case DiffType.Deleted:
-                        return (
-                            <li className="duty-deleted">
-                                {oldDuty!.description} - {oldDuty!.hours}h
-                            </li>
-                        );
-                    default:
-                        return null as never;
-                }
-            })}
+            {changes.map(({ oldDuty, newDuty, status }) => (
+                <DutyItem oldDuty={oldDuty} newDuty={newDuty} status={status} />
+            ))}
         </ul>
     );
 }
@@ -126,8 +129,9 @@ function DdahsList({ ddahs }: { ddahs: Omit<Ddah, "id">[] }) {
                     {applicant.utorid})
                     <ul className="instructor-ddah-import-new-ddah-duties-list">
                         {duties.map((duty) => (
-                            <li key={`ddah-new-${i}`}>
-                                {duty.description} - {duty.hours}h
+                            <li key={i}>
+                                <span>{duty.description}</span> -{" "}
+                                <span>{duty.hours}h</span>
                             </li>
                         ))}
                     </ul>

--- a/frontend/src/views/instructor/ddahs/import.tsx
+++ b/frontend/src/views/instructor/ddahs/import.tsx
@@ -88,29 +88,28 @@ function dutiesDiffList(changes: DutyDiff[]) {
                 switch (status) {
                     case DiffType.Unchanged:
                         return (
-                            <li>
-                                {oldDuty!.description} - {oldDuty!.hours}
+                            <li className="duty-unchanged">
+                                {oldDuty!.description} - {oldDuty!.hours}h
                             </li>
                         );
                     case DiffType.Updated:
                         return (
-                            <li>
-                                {oldDuty!.description} - {oldDuty!.hours}{" "}
-                                <FaArrowRight /> {newDuty!.description} -{" "}
-                                {newDuty!.hours}{" "}
+                            <li className="duty-updated">
+                                {oldDuty!.description} - {oldDuty!.hours}h{" "}
+                                <FaArrowRight />
+                                {newDuty!.hours}h
                             </li>
                         );
                     case DiffType.Created:
                         return (
-                            <li>
-                                {newDuty!.description} - {newDuty!.hours} (new)
+                            <li className="duty-created">
+                                {newDuty!.description} - {newDuty!.hours}h
                             </li>
                         );
                     case DiffType.Deleted:
                         return (
-                            <li>
-                                {oldDuty!.description} - {oldDuty!.hours}{" "}
-                                (deleted)
+                            <li className="duty-deleted">
+                                {oldDuty!.description} - {oldDuty!.hours}h
                             </li>
                         );
                     default:
@@ -128,11 +127,13 @@ function DdahsList({ ddahs }: { ddahs: Omit<Ddah, "id">[] }) {
                 <li>
                     DDAH for {applicant.first_name} {applicant.last_name} (
                     {applicant.utorid})
-                    {duties.map((duty) => (
-                        <li>
-                            {duty.description} - {duty.hours}
-                        </li>
-                    ))}
+                    <ul>
+                        {duties.map((duty) => (
+                            <li>
+                                {duty.description} - {duty.hours}h
+                            </li>
+                        ))}
+                    </ul>
                 </li>
             ))}
         </ul>
@@ -141,7 +142,7 @@ function DdahsList({ ddahs }: { ddahs: Omit<Ddah, "id">[] }) {
 
 function DdahsDiffList({ ddahUpdates }: { ddahUpdates: DdahUpdate[] }) {
     return (
-        <ul>
+        <ul className="instructor-ddah-import-duties-diff-list">
             {ddahUpdates.map(({ oldDdah, updatedDdah }) => {
                 const dutiesDiff = getDutiesDiff(
                     oldDdah.duties,
@@ -253,10 +254,7 @@ export function InstructorImportDdahsAction({
     return (
         <ImportActionButton
             onConfirm={onConfirm}
-            onFileChange={(content: any) => {
-                console.log(content);
-                setFileContent(content);
-            }}
+            onFileChange={setFileContent}
             dialogContent={
                 <DialogContent
                     processingError={processingError}

--- a/frontend/src/views/instructor/ddahs/import.tsx
+++ b/frontend/src/views/instructor/ddahs/import.tsx
@@ -1,0 +1,311 @@
+import React from "react";
+import { Alert } from "react-bootstrap";
+import { FaArrowRight } from "react-icons/fa";
+import { useSelector } from "react-redux";
+import { assignmentsSelector, applicantsSelector } from "../../../api/actions";
+import { ddahsSelector, upsertDdahs } from "../../../api/actions/ddahs";
+import {
+    Ddah,
+    Assignment,
+    Applicant,
+    MinimalDdah,
+    RawDuty,
+} from "../../../api/defs/types";
+import { ImportActionButton } from "../../../components/import-button";
+import { DiffSpec, diffImport, getChanged } from "../../../libs/diffs";
+import { normalizeDdahImports } from "../../../libs/import-export";
+import { useThunkDispatch } from "../../../libs/thunk-dispatch";
+
+enum DiffType {
+    Unchanged = "UNCHANGED",
+    Created = "CREATED",
+    Updated = "UPDATED",
+    Deleted = "DELETED",
+}
+
+type MinimalDuty = {
+    description: string;
+    hours: number;
+};
+
+interface DdahUpdate {
+    updatedDdah: Ddah;
+    oldDdah: Ddah;
+}
+
+interface DutyDiff {
+    oldDuty?: MinimalDuty;
+    newDuty?: MinimalDuty;
+    status: DiffType;
+}
+
+function getDutiesDiff(oldDuties: RawDuty[], newDuties: RawDuty[]) {
+    let changes: DutyDiff[] = [];
+    let dutiesChanged = false;
+
+    oldDuties.forEach((oldDuty) => {
+        let oldDutyDeleted = true;
+
+        newDuties.forEach((newDuty, index) => {
+            if (
+                oldDuty.description === newDuty.description &&
+                oldDuty.hours === newDuty.hours
+            ) {
+                changes.push({ oldDuty, newDuty, status: DiffType.Unchanged });
+                newDuties.splice(index, 1);
+                oldDutyDeleted = false;
+            } else if (
+                oldDuty.description === newDuty.description &&
+                oldDuty.hours !== newDuty.hours
+            ) {
+                changes.push({ oldDuty, newDuty, status: DiffType.Updated });
+                newDuties.splice(index, 1);
+                oldDutyDeleted = false;
+                dutiesChanged = true;
+            }
+        });
+
+        // If we did not find old duties to match the new one - mark it as created
+        if (oldDutyDeleted) {
+            changes.push({ oldDuty, status: DiffType.Deleted });
+            dutiesChanged = true;
+        }
+    });
+
+    // The new duties that are left were just created - add them
+    newDuties.forEach((duty) =>
+        changes.push({ newDuty: duty, status: DiffType.Created })
+    );
+
+    // Do not return changes if everything is unchanged
+    return dutiesChanged ? changes : [];
+}
+
+function dutiesDiffList(changes: DutyDiff[]) {
+    return (
+        <ul>
+            {changes.map(({ oldDuty, newDuty, status }) => {
+                switch (status) {
+                    case DiffType.Unchanged:
+                        return (
+                            <li>
+                                {oldDuty!.description} - {oldDuty!.hours}
+                            </li>
+                        );
+                    case DiffType.Updated:
+                        return (
+                            <li>
+                                {oldDuty!.description} - {oldDuty!.hours}{" "}
+                                <FaArrowRight /> {newDuty!.description} -{" "}
+                                {newDuty!.hours}{" "}
+                            </li>
+                        );
+                    case DiffType.Created:
+                        return (
+                            <li>
+                                {newDuty!.description} - {newDuty!.hours} (new)
+                            </li>
+                        );
+                    case DiffType.Deleted:
+                        return (
+                            <li>
+                                {oldDuty!.description} - {oldDuty!.hours}{" "}
+                                (deleted)
+                            </li>
+                        );
+                    default:
+                        return null;
+                }
+            })}
+        </ul>
+    );
+}
+
+function DdahsList({ ddahs }: { ddahs: Omit<Ddah, "id">[] }) {
+    return (
+        <ul>
+            {ddahs.map(({ assignment: { applicant }, duties }) => (
+                <li>
+                    DDAH for {applicant.first_name} {applicant.last_name} (
+                    {applicant.utorid})
+                    {duties.map((duty) => (
+                        <li>
+                            {duty.description} - {duty.hours}
+                        </li>
+                    ))}
+                </li>
+            ))}
+        </ul>
+    );
+}
+
+function DdahsDiffList({ ddahUpdates }: { ddahUpdates: DdahUpdate[] }) {
+    return (
+        <ul>
+            {ddahUpdates.map(({ oldDdah, updatedDdah }) => {
+                const dutiesDiff = getDutiesDiff(
+                    oldDdah.duties,
+                    updatedDdah.duties
+                );
+                const {
+                    assignment: {
+                        applicant: { first_name, last_name, utorid },
+                    },
+                } = updatedDdah;
+                return (
+                    <li>
+                        DDAH for {first_name} {last_name} ({utorid})
+                        {dutiesDiffList(dutiesDiff)}
+                    </li>
+                );
+            })}
+        </ul>
+    );
+}
+
+export function InstructorImportDdahsAction({
+    disabled = false,
+    setImportInProgress = null,
+}: {
+    disabled: boolean;
+    setImportInProgress?: Function | null;
+}) {
+    const dispatch = useThunkDispatch();
+    const ddahs = useSelector<any, Ddah[]>(ddahsSelector);
+    const assignments = useSelector<any, Assignment[]>(assignmentsSelector);
+    const applicants = useSelector<any, Applicant[]>(applicantsSelector);
+    const [fileContent, setFileContent] = React.useState<{
+        fileType: "json" | "spreadsheet";
+        data: any;
+    } | null>(null);
+    const [diffed, setDiffed] = React.useState<
+        DiffSpec<MinimalDdah, Ddah>[] | null
+    >(null);
+    const [newDdahs, setNewDdahs] = React.useState<(Ddah | Omit<Ddah, "id">)[]>(
+        []
+    );
+    const [ddahUpdates, setDdahUpdates] = React.useState<DdahUpdate[]>([]);
+    const [processingError, setProcessingError] = React.useState(null);
+    const [inProgress, _setInProgress] = React.useState(false);
+
+    function setInProgress(state: boolean) {
+        _setInProgress(state);
+        if (typeof setImportInProgress === "function") {
+            setImportInProgress(state);
+        }
+    }
+
+    // Make sure we aren't showing any diff if there's no file loaded.
+    React.useEffect(() => {
+        if (!fileContent) {
+            if (diffed) {
+                setDiffed(null);
+            }
+        }
+    }, [diffed, setDiffed, fileContent]);
+
+    // Recompute the diff every time the file changes
+    React.useEffect(() => {
+        // If we have no file or we are currently in the middle of processing another file,
+        // do nothing.
+        if (!fileContent || inProgress) {
+            return;
+        }
+        try {
+            setProcessingError(null);
+            // normalize the data coming from the file
+            const data = normalizeDdahImports(fileContent, applicants);
+
+            // Compute which DDAHs have been added/modified
+            const newDiff = diffImport.ddahs(data, { ddahs, assignments });
+            const newDdahs = newDiff
+                .filter((diff) => diff.status === "new")
+                .map((diff) => diff.obj);
+            const modifiedDdahs = newDiff
+                .filter((diff) => diff.status === "modified")
+                .map((diff) => diff.obj as Ddah);
+            const ddahUpdates = modifiedDdahs.map((modifiedDdah) => ({
+                updatedDdah: modifiedDdah,
+                oldDdah: ddahs.find(
+                    (ddah) => ddah.id === modifiedDdah.id
+                ) as Ddah,
+            }));
+            setNewDdahs(newDdahs);
+            setDdahUpdates(ddahUpdates);
+            setDiffed(newDiff);
+        } catch (e) {
+            console.warn(e);
+            setProcessingError(e);
+        }
+    }, [fileContent, ddahs, assignments, applicants, inProgress]);
+
+    async function onConfirm() {
+        if (!diffed) {
+            throw new Error("Unable to compute an appropriate diff");
+        }
+        const changedDdahs = getChanged(diffed);
+
+        await dispatch(upsertDdahs(changedDdahs));
+
+        setFileContent(null);
+    }
+
+    return (
+        <ImportActionButton
+            onConfirm={onConfirm}
+            onFileChange={setFileContent}
+            dialogContent={
+                <DialogContent
+                    processingError={processingError}
+                    newDdahs={newDdahs}
+                    ddahUpdates={ddahUpdates}
+                />
+            }
+            setInProgress={setInProgress}
+            disabled={disabled}
+        />
+    );
+}
+
+const DialogContent = React.memo(function DialogContent({
+    processingError,
+    newDdahs,
+    ddahUpdates,
+}: {
+    processingError: string | null;
+    newDdahs: (Ddah | Omit<Ddah, "id">)[];
+    ddahUpdates: DdahUpdate[];
+}) {
+    if (processingError) {
+        return <Alert variant="danger">{"" + processingError}</Alert>;
+    }
+
+    if (newDdahs.length === 0 && ddahUpdates.length === 0) {
+        return (
+            <Alert variant="warning">
+                No difference between imported and existing DDAHs.
+            </Alert>
+        );
+    }
+
+    return (
+        <>
+            {newDdahs.length > 0 && (
+                <Alert variant="primary">
+                    <span className="mb-1">
+                        The following DDAHs will be <strong>added</strong>
+                    </span>
+                    <DdahsList ddahs={newDdahs} />
+                </Alert>
+            )}
+            {ddahUpdates.length > 0 && (
+                <Alert variant="info">
+                    <span className="mb-1">
+                        The following DDAHs will be <strong>modified</strong>
+                    </span>
+                    <DdahsDiffList ddahUpdates={ddahUpdates} />
+                </Alert>
+            )}
+        </>
+    );
+});

--- a/frontend/src/views/instructor/ddahs/import.tsx
+++ b/frontend/src/views/instructor/ddahs/import.tsx
@@ -253,17 +253,21 @@ export function InstructorImportDdahsAction({
     return (
         <ImportActionButton
             onConfirm={onConfirm}
-            onFileChange={setFileContent}
+            onFileChange={(content: any) => {
+                console.log(content);
+                setFileContent(content);
+            }}
             dialogContent={
                 <DialogContent
                     processingError={processingError}
                     newDdahs={newDdahs}
                     ddahUpdates={ddahUpdates}
+                    fileLoaded={!!diffed && !inProgress}
                 />
             }
             setInProgress={setInProgress}
             disabled={disabled}
-        />
+        ></ImportActionButton>
     );
 }
 
@@ -271,13 +275,20 @@ const DialogContent = React.memo(function DialogContent({
     processingError,
     newDdahs,
     ddahUpdates,
+    fileLoaded,
 }: {
     processingError: string | null;
     newDdahs: (Ddah | Omit<Ddah, "id">)[];
     ddahUpdates: DdahUpdate[];
+    fileLoaded: boolean;
 }) {
     if (processingError) {
         return <Alert variant="danger">{"" + processingError}</Alert>;
+    }
+
+    if (!fileLoaded) {
+        console.log("Clear!");
+        return <p>No data loaded.</p>;
     }
 
     if (newDdahs.length === 0 && ddahUpdates.length === 0) {

--- a/frontend/src/views/instructor/ddahs/index.tsx
+++ b/frontend/src/views/instructor/ddahs/index.tsx
@@ -13,14 +13,12 @@ import { ddahsSelector, upsertDdah } from "../../../api/actions/ddahs";
 import { DdahPreviewModal } from "./ddah-editor";
 import { useThunkDispatch } from "../../../libs/thunk-dispatch";
 import { activePositionSelector, setDdahForEmailIds } from "../store/actions";
-import {
-    ConnectedExportDdahsAction,
-    ConnectedImportDdahsAction,
-} from "../../admin/ddahs/import-export";
+import { ConnectedExportDdahsAction } from "../../admin/ddahs/import-export";
 import { setSelectedRows as setSelectedDdahs } from "../../admin/ddah-table/actions";
 import { formatDate } from "../../../libs/utils";
 import { DdahEmailModal } from "./ddah-emailer";
 import { FaMailBulk } from "react-icons/fa";
+import { InstructorImportDdahsAction } from "./import";
 
 export function InstructorDdahsView() {
     const activeSession = useSelector(activeSessionSelector);
@@ -100,7 +98,7 @@ export function InstructorDdahsView() {
                     Email DDAHs
                 </ActionButton>
                 <ActionHeader>Import/Export</ActionHeader>
-                <ConnectedImportDdahsAction disabled={!activeSession} />
+                <InstructorImportDdahsAction disabled={!activeSession} />
                 <ConnectedExportDdahsAction disabled={!activeSession} />
             </ActionsList>
             <ContentArea>

--- a/frontend/src/views/instructor/ddahs/style.css
+++ b/frontend/src/views/instructor/ddahs/style.css
@@ -39,3 +39,37 @@
     align-self: center;
     font-style: italic;
 }
+
+.instructor-ddah-import-duties-diff-list .duty-created {
+    list-style-type: "\2713";
+}
+
+.instructor-ddah-import-duties-diff-list .duty-created:after {
+    content: " (new)";
+    color: green;
+    font-weight: bold;
+}
+
+.instructor-ddah-import-duties-diff-list .duty-updated {
+    list-style-type: "\270F";
+    padding-left: 2px;
+}
+
+.instructor-ddah-import-duties-diff-list .duty-updated:after {
+    content: " (updated)";
+    color: orange;
+}
+
+.instructor-ddah-import-duties-diff-list .duty-deleted {
+    list-style-type: "\2717";
+}
+
+.instructor-ddah-import-duties-diff-list .duty-deleted:after {
+    color: red;
+    content: " (deleted)";
+    font-weight: bold;
+}
+
+.instructor-ddah-import-duties-diff-list .duty-unchanged {
+    color:grey;
+}

--- a/frontend/src/views/instructor/ddahs/style.css
+++ b/frontend/src/views/instructor/ddahs/style.css
@@ -71,5 +71,5 @@
 }
 
 .instructor-ddah-import-duties-diff-list .duty-unchanged {
-    color:grey;
+    color: grey;
 }

--- a/frontend/src/views/instructor/ddahs/style.css
+++ b/frontend/src/views/instructor/ddahs/style.css
@@ -73,3 +73,7 @@
 .instructor-ddah-import-duties-diff-list .duty-unchanged {
     color: grey;
 }
+
+.instructor-ddah-import-new-ddah-duties-list li {
+    list-style-type: "\2713";
+}

--- a/frontend/src/views/instructor/ddahs/style.css
+++ b/frontend/src/views/instructor/ddahs/style.css
@@ -41,7 +41,7 @@
 }
 
 .instructor-ddah-import-duties-diff-list .duty-created {
-    list-style-type: "\2713";
+    list-style-type: "✓";
 }
 
 .instructor-ddah-import-duties-diff-list .duty-created:after {
@@ -51,7 +51,7 @@
 }
 
 .instructor-ddah-import-duties-diff-list .duty-updated {
-    list-style-type: "\270F";
+    list-style-type: "✏";
     padding-left: 2px;
 }
 
@@ -61,7 +61,7 @@
 }
 
 .instructor-ddah-import-duties-diff-list .duty-deleted {
-    list-style-type: "\2717";
+    list-style-type: "✗";
 }
 
 .instructor-ddah-import-duties-diff-list .duty-deleted:after {


### PR DESCRIPTION
This PR fixes several problems with the import UI for DDAHs in the instructor view:

1. Duties of the modified/created DDAHs are no longer a single string - they are rendered as a list with visual cues to see what will be the difference after import:

![image](https://user-images.githubusercontent.com/23097023/130336172-00bb449f-93a7-411e-aacd-ee7f5172a7fe.png)
![image](https://user-images.githubusercontent.com/23097023/130336177-a32d4097-5521-4019-84cf-d45fa3a3caa6.png)

2. The import modal clears the name of the file on hitting 'Cancel' and preserves the filename along with changes when closed.
TODO: clear duties diff on 'Cancel' - component updates before unmounting