### PR TITLE
Overcoming the issue of Safari not having date type for input

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
         "bootstrap": "^4.5.3",
         "chrono-node": "^2.1.10",
         "classnames": "^2.2.6",
+        "date-input-polyfill": "^2.14.0",
         "file-saver": "^2.0.5",
         "fuzzyset": "^1.0.6",
         "jszip": "^3.5.0",

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -5,6 +5,7 @@ import { HashRouter } from "react-router-dom";
 import { PersistGate } from "redux-persist/integration/react";
 import DynamicEntryRouter from "./dynamic-entry-router";
 import configureStore from "./store";
+import "date-input-polyfill";
 
 const { store, persistor } = configureStore();
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2905,7 +2905,7 @@ babel-preset-react-app@^10.0.0:
     babel-plugin-macros "2.8.0"
     babel-plugin-transform-react-remove-prop-types "0.4.24"
 
-babel-runtime@^6.26.0:
+babel-runtime@^6.11.6, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
@@ -4206,6 +4206,13 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
+
+date-input-polyfill@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/date-input-polyfill/-/date-input-polyfill-2.14.0.tgz#9b2e569effc525796101d3199b9ae731c8a50e12"
+  integrity sha1-my5Wnv/FJXlhAdMZm5rnMcilDhI=
+  dependencies:
+    babel-runtime "^6.11.6"
 
 dayjs@^1.10.0:
   version "1.10.4"


### PR DESCRIPTION
Installed the polyfill https://www.npmjs.com/package/date-input-polyfill  for issue #626. Even though Safari 14.1 comes with the date input type support, I have installed this polyfill, hoping it fixes this issue for the older versions of Safari.