### PR TITLE
Raise an ActiveRecord::RecordNotFound when no assignment exists.

### DIFF
--- a/backend/app/controllers/api/v1/instructor/ddahs_controller.rb
+++ b/backend/app/controllers/api/v1/instructor/ddahs_controller.rb
@@ -74,7 +74,7 @@ class Api::V1::Instructor::DdahsController < ApplicationController
 
         # look up the DDAH first by assignment ID, otherwise, create a new DDAH
         if params[:assignment_id]
-            assignment = Assignment.find_by(id: params[:assignment_id])
+            assignment = Assignment.find_by!(id: params[:assignment_id])
             if assignment.accessible_by_instructor(@active_instructor.id)
                 @ddah = assignment.ddah || Ddah.new(ddah_params)
             end


### PR DESCRIPTION
This PR forces to throw an ActiveRecord::RecordNotFound when no assignment with a given id exists. This improves the debugging experience and terminates early to prevent any potential mishandlings of the `nil` object returned by `find_by` (without exclamation mark).