### PR TITLE
Added Assignments Summary to Matching view

### DIFF
--- a/backend/app/models/offer.rb
+++ b/backend/app/models/offer.rb
@@ -47,8 +47,8 @@ class Offer < ApplicationRecord
         formatting_service =
             WageChunkFormattingService.new(assignment: assignment)
         self.pay_period_desc = formatting_service.pay_period_description
-        self.position_start_date = position.start_date
-        self.position_end_date = position.end_date
+        self.position_start_date = assignment.start_date || position.start_date
+        self.position_end_date = assignment.end_date || position.end_date
         self.ta_coordinator_email =
             Rails.application.config.ta_coordinator_email
         self.ta_coordinator_name = Rails.application.config.ta_coordinator_name

--- a/frontend/src/api/actions/ddahs.ts
+++ b/frontend/src/api/actions/ddahs.ts
@@ -22,6 +22,7 @@ import { ddahsReducer } from "../reducers";
 import { assignmentsSelector } from "./assignments";
 import type { Ddah, RawAttachment, RawDdah } from "../defs/types";
 import { activeSessionSelector } from "./sessions";
+import { round } from "../../libs/utils";
 
 // actions
 const fetchDdahsSuccess = actionFactory<RawDdah[]>(FETCH_DDAHS_SUCCESS);
@@ -232,7 +233,7 @@ function computeDdahHours(ddah: Pick<Ddah, "duties">) {
     for (const duty of ddah.duties) {
         ret += duty.hours;
     }
-    return ret;
+    return round(ret, 2);
 }
 
 // Each reducer is given an isolated state; instead of needing to remember to

--- a/frontend/src/libs/ddah-utils.ts
+++ b/frontend/src/libs/ddah-utils.ts
@@ -8,7 +8,7 @@ import type { Ddah } from "../api/defs/types";
  * @returns
  */
 export function ddahIssues(ddah: Ddah) {
-    if (ddah.total_hours !== ddah.assignment.hours) {
+    if (Math.abs(ddah.total_hours - ddah.assignment.hours) > 0.001) {
         return `Hours Mismatch (${ddah.total_hours} vs. ${ddah.assignment.hours})`;
     }
     return null;

--- a/frontend/src/libs/import-export/prepare-full.ts
+++ b/frontend/src/libs/import-export/prepare-full.ts
@@ -19,6 +19,7 @@ import {
     Posting,
     PostingPosition,
 } from "../../api/defs/types";
+import { round } from "../utils";
 
 /**
  * The function type of a function that creates an upsertable
@@ -298,6 +299,7 @@ export const prepareFull: PrepareFull = {
         for (const duty of duties) {
             total_hours += duty.hours;
         }
+        total_hours = round(total_hours, 2);
 
         if (id == null) {
             return {

--- a/frontend/src/libs/utils.ts
+++ b/frontend/src/libs/utils.ts
@@ -199,3 +199,10 @@ export function formatMoney(moneyString: string): string {
     }
     return parseFloat(moneyString).toFixed(2);
 }
+
+/**
+ * Round `x` to `places` number of decimal places.
+ */
+export function round(x: number, places: number = 0) {
+    return Math.round(x * Math.pow(10, places)) / Math.pow(10, places);
+}

--- a/frontend/src/tests/offer-tests.js
+++ b/frontend/src/tests/offer-tests.js
@@ -564,6 +564,10 @@ export function offerEmailTests(api) {
             );
         }
     });
+
+    it.todo(
+        "Offer's position_start_date/end_date matches that of the assignment if the assignment and position have different start/end dates"
+    );
 }
 
 /**

--- a/frontend/src/views/admin/admin-header/header.tsx
+++ b/frontend/src/views/admin/admin-header/header.tsx
@@ -66,6 +66,11 @@ export const ROUTES = [
                 name: "Applications",
                 description: "Manage Applications",
             },
+            {
+                route: "/matching",
+                name: "Matching",
+                description: "Match applicants to positions",
+            },
         ],
     },
 ];

--- a/frontend/src/views/admin/assignments/edit-assignment-dialog.tsx
+++ b/frontend/src/views/admin/assignments/edit-assignment-dialog.tsx
@@ -1,0 +1,155 @@
+import React from "react";
+import { Modal, Button, Spinner, Alert } from "react-bootstrap";
+import {
+    AssignmentEditor,
+    NullableAssignment,
+} from "../../../components/forms/assignment-editor";
+import { Assignment } from "../../../api/defs/types";
+import { useThunkDispatch } from "../../../libs/thunk-dispatch";
+import { upsertAssignment } from "../../../api/actions";
+
+function generateNullableAssignment(
+    assignment: Assignment
+): NullableAssignment {
+    return {
+        ...assignment,
+        position_id: assignment.position.id,
+        applicant_id: assignment.applicant.id,
+    };
+}
+
+export function EditAssignmentDialog({
+    show,
+    onHide,
+    assignment,
+    upsertAssignment,
+}: {
+    show: boolean;
+    onHide: (...args: any[]) => void;
+    assignment: Assignment;
+    upsertAssignment: (assignment: Partial<Assignment>) => any;
+}) {
+    const [newAssignment, setNewAssignment] =
+        React.useState<NullableAssignment>(() =>
+            generateNullableAssignment(assignment)
+        );
+    const [inProgress, setInProgress] = React.useState(false);
+
+    React.useEffect(() => {
+        if (!show) {
+            // If the dialog is hidden, reset the state
+            setNewAssignment(generateNullableAssignment(assignment));
+        }
+    }, [show, assignment]);
+
+    async function createAssignment() {
+        setInProgress(true);
+        try {
+            const assignmentToUpsert = { ...newAssignment };
+            // Special care must be taken to ensure that the wageChunks and the start/end
+            // dates match up. If the dates have changed, we may need to create new wageChunks
+            if (
+                (assignmentToUpsert.start_date !== assignment.start_date ||
+                    assignmentToUpsert.end_date !== assignment.end_date) &&
+                !assignmentToUpsert.wage_chunks
+            ) {
+                assignmentToUpsert.wage_chunks = [
+                    {
+                        start_date: assignmentToUpsert.start_date,
+                        end_date: assignmentToUpsert.end_date,
+                        hours: assignmentToUpsert.hours,
+                    },
+                ];
+            }
+            await upsertAssignment(assignmentToUpsert as Partial<Assignment>);
+        } finally {
+            setInProgress(false);
+        }
+        onHide();
+    }
+
+    // When a confirm operation is in progress, a spinner is displayed; otherwise
+    // it's hidden
+    const spinner = inProgress ? (
+        <Spinner animation="border" size="sm" className="mr-1" />
+    ) : null;
+
+    const conflicts: { immediateShow?: React.ReactNode } = {};
+
+    if (
+        ["rejected", "pending", "accepted"].includes(
+            assignment.active_offer_status || ""
+        )
+    ) {
+        conflicts.immediateShow = (
+            <React.Fragment>
+                This assignment currently has an active offer. You must first{" "}
+                <b>withdraw</b> the existing offer before making a modification.
+            </React.Fragment>
+        );
+    }
+
+    return (
+        <Modal show={show} onHide={onHide}>
+            <Modal.Header closeButton>
+                <Modal.Title>Edit Assignment</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <AssignmentEditor
+                    positions={[assignment.position]}
+                    applicants={[assignment.applicant]}
+                    assignment={newAssignment}
+                    setAssignment={setNewAssignment}
+                    lockPositionAndApplicant={true}
+                />
+                {!inProgress && conflicts.immediateShow ? (
+                    <Alert variant="danger">{conflicts.immediateShow}</Alert>
+                ) : null}
+            </Modal.Body>
+            <Modal.Footer>
+                <Button onClick={onHide} variant="light">
+                    Cancel
+                </Button>
+                <Button
+                    onClick={createAssignment}
+                    title={"Modify Assignment"}
+                    disabled={!!conflicts.immediateShow}
+                >
+                    {spinner}
+                    Modify Assignment
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+}
+
+export function ConnectedEditAssignmentDialog({
+    assignment,
+    show,
+    onHide,
+}: {
+    assignment: Assignment | null | undefined;
+    show: boolean;
+    onHide: (...args: any[]) => void;
+}) {
+    const dispatch = useThunkDispatch();
+    const _upsertAssignment = React.useCallback(
+        async (assignment: Partial<Assignment>) => {
+            await dispatch(upsertAssignment(assignment));
+        },
+        [dispatch]
+    );
+
+    if (!assignment) {
+        return null;
+    }
+
+    return (
+        <EditAssignmentDialog
+            show={show}
+            onHide={onHide}
+            assignment={assignment}
+            upsertAssignment={_upsertAssignment}
+        />
+    );
+}

--- a/frontend/src/views/admin/assignments/index.tsx
+++ b/frontend/src/views/admin/assignments/index.tsx
@@ -14,7 +14,7 @@ import {
     ActionHeader,
 } from "../../../components/action-buttons";
 import { ContentArea } from "../../../components/layout";
-import { FaPlus } from "react-icons/fa";
+import { FaEdit, FaPlus } from "react-icons/fa";
 import { MissingActiveSessionWarning } from "../../../components/sessions";
 import { useSelector } from "react-redux";
 import {
@@ -24,9 +24,11 @@ import {
 import { Spinner } from "react-bootstrap";
 import { offerTableSelector } from "../offertable/actions";
 import { Assignment } from "../../../api/defs/types";
+import { ConnectedEditAssignmentDialog } from "./edit-assignment-dialog";
 
 export function AdminAssignmentsView() {
     const [addDialogVisible, setAddDialogVisible] = React.useState(false);
+    const [editDialogVisible, setEditDialogVisible] = React.useState(false);
     const activeSession = useSelector(activeSessionSelector);
     // While data is being imported, updating the react table takes a long time,
     // so we use this variable to hide the react table during import.
@@ -73,6 +75,18 @@ export function AdminAssignmentsView() {
                 <ConnectedOfferActionButtons
                     selectedAssignments={selectedAssignments}
                 />
+                <ActionButton
+                    disabled={!(selectedAssignments.length === 1)}
+                    title={
+                        selectedAssignments.length === 1
+                            ? "Edit the selected assignment"
+                            : "Please select a single assignment to edit (you cannot edit multiple assignments at the same time)"
+                    }
+                    onClick={() => setEditDialogVisible(true)}
+                    icon={<FaEdit />}
+                >
+                    Edit Assignment
+                </ActionButton>
             </ActionsList>
             <ContentArea>
                 {activeSession ? null : (
@@ -92,6 +106,13 @@ export function AdminAssignmentsView() {
                     onHide={() => {
                         setAddDialogVisible(false);
                     }}
+                />
+                <ConnectedEditAssignmentDialog
+                    show={editDialogVisible}
+                    onHide={() => {
+                        setEditDialogVisible(false);
+                    }}
+                    assignment={selectedAssignments[0]}
                 />
             </ContentArea>
         </div>

--- a/frontend/src/views/admin/matching/applicant-pill.css
+++ b/frontend/src/views/admin/matching/applicant-pill.css
@@ -1,0 +1,32 @@
+.applicant-pill {
+    display: inline-flex;
+    border-radius: 8px;
+    font-size: small;
+    background-color: hsl(134, 61%, 70%);
+    padding: 2px 4px 3px 2px;
+    margin: 1px;
+    height: 35px;
+    width: 150px;
+    overflow: hidden;
+    line-height: 15px;
+}
+.applicant-pill .annotation {
+    padding: 4px 5px 4px 4px;
+    margin-left: 0;
+    margin-right: 2px;
+    font-size: 15px;
+    border-radius: 8px;
+    background-color: rgba(3, 3, 3, 0.25);
+    color: #fff;
+    display: flex;
+    align-items: center;
+}
+.applicant-pill .pill-body {
+    overflow: hidden;
+    flex-grow: 1;
+}
+.applicant-pill .name {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}

--- a/frontend/src/views/admin/matching/applicant-pill.tsx
+++ b/frontend/src/views/admin/matching/applicant-pill.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import {
+    applicationsSelector,
+    assignmentsSelector,
+} from "../../../api/actions";
+import { Applicant } from "../../../api/defs/types";
+import { sum } from "../../../api/mockAPI/utils";
+
+import "./applicant-pill.css";
+
+export function ApplicantPill({ applicant }: { applicant: Applicant }) {
+    const applications = useSelector(applicationsSelector);
+    const assignments = useSelector(assignmentsSelector);
+
+    const application = React.useMemo(() => {
+        const matchingApplications = applications.filter(
+            (application) => application.applicant.id === applicant.id
+        );
+        if (matchingApplications.length === 0) {
+            return null;
+        }
+        if (matchingApplications.length === 1) {
+            return matchingApplications[0];
+        }
+        // We need to find the most recently completed application
+        matchingApplications.sort((a, b) => {
+            if (a.submission_date === b.submission_date) {
+                return 0;
+            }
+            if (a.submission_date > b.submission_date) {
+                return 1;
+            }
+            return -1;
+        });
+        return matchingApplications[matchingApplications.length - 1];
+    }, [applications, applicant]);
+
+    let annotation = "?";
+    if (application) {
+        annotation = `${application.annotation || ""}${
+            application.program || "?"
+        }${application.yip == null ? "" : application.yip}`;
+    }
+
+    const activeAssignments = React.useMemo(() => {
+        return assignments.filter(
+            (assignment) =>
+                assignment.applicant.id === applicant.id &&
+                ["accepted", "pending", "provisional"].includes(
+                    assignment.active_offer_status || ""
+                )
+        );
+    }, [applicant, assignments]);
+    const assignedHours = sum(
+        ...activeAssignments.map((assignment) => assignment.hours)
+    );
+
+    return (
+        <div className="applicant-pill">
+            <div className="annotation">{annotation}</div>
+            <div className="pill-body">
+                <div className="name">
+                    {applicant.first_name} {applicant.last_name}
+                </div>
+                <div className="hours">{assignedHours} hours</div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/views/admin/matching/grouped-overview.css
+++ b/frontend/src/views/admin/matching/grouped-overview.css
@@ -1,0 +1,75 @@
+.assignments-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+.position-label {
+    display: inline-block;
+    width: 9em;
+    background-color: var(--light);
+    padding: 4px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+.position-label.matched {
+    background-color: var(--green);
+    color: var(--white);
+}
+.position-label.over {
+    background-color: var(--orange);
+    color: var(--white);
+}
+
+.position-label .position-code,
+.position-label .position-title {
+    display: block;
+    text-align: center;
+}
+.position-label .position-title {
+    font-size: smaller;
+}
+.position-label .additional-info {
+    font-size: smaller;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0px 4px;
+    justify-content: center;
+}
+
+.position-label .position-hours::before {
+    content: "Hours: ";
+}
+.position-label .position-filled::before {
+    content: "Filled: ";
+}
+.position-label .position-hours-filled::before {
+    content: "Hours Filled: ";
+}
+
+.position-row {
+    display: flex;
+}
+.position-row-body {
+    display: flex;
+    flex-grow: 1;
+}
+.position-row-body .row-division {
+    display: flex;
+    flex-direction: column;
+}
+.position-row-body .row-division:first-child {
+    flex-grow: 1;
+}
+.position-row-body .row-division-header {
+    font-size: smaller;
+    text-align: center;
+    border-bottom: 0.5px solid rgba(0, 0, 0, 0.5);
+}
+.position-row-body .row-division-body {
+    flex-grow: 1;
+    display: flex;
+    flex-wrap: wrap;
+}
+.position-row-body .row-division:nth-child(2n) {
+    background-color: rgba(20, 0, 200, 0.07);
+}

--- a/frontend/src/views/admin/matching/grouped-overview.tsx
+++ b/frontend/src/views/admin/matching/grouped-overview.tsx
@@ -1,0 +1,186 @@
+import classNames from "classnames";
+import React from "react";
+import { useSelector } from "react-redux";
+import { assignmentsSelector, positionsSelector } from "../../../api/actions";
+import { Assignment, Position } from "../../../api/defs/types";
+import { sum } from "../../../api/mockAPI/utils";
+import { round } from "../../../libs/utils";
+import { ApplicantPill } from "./applicant-pill";
+
+import "./grouped-overview.css";
+
+type PositionSummary = {
+    assignments: Assignment[];
+    numActiveAssignments: number;
+    hoursAssigned: number;
+    filledStatus: "under" | "over" | "matched";
+};
+
+function PositionLabel({
+    position,
+    summary,
+}: {
+    position: Position;
+    summary: PositionSummary;
+}) {
+    const targetHours = round(
+        position.hours_per_assignment * (position.desired_num_assignments || 0),
+        2
+    );
+
+    return (
+        <div className={classNames("position-label", summary.filledStatus)}>
+            <span className="position-code">{position.position_code}</span>
+            <div className="additional-info">
+                <span className="position-hours">
+                    {position.hours_per_assignment}
+                </span>
+                <span className="position-filled">
+                    {summary.numActiveAssignments}
+                    {position.desired_num_assignments != null ? "/" : ""}
+                    {position.desired_num_assignments}
+                </span>
+                <span className="position-hours-filled">
+                    {summary.hoursAssigned}/{targetHours}
+                </span>
+            </div>
+        </div>
+    );
+}
+
+function PositionRow({
+    position,
+    summary,
+}: {
+    position: Position;
+    summary: PositionSummary;
+}) {
+    const activeAssignments = React.useMemo(() => {
+        return summary.assignments.filter((assignment) =>
+            ["accepted", "provisional", "pending"].includes(
+                assignment.active_offer_status || ""
+            )
+        );
+    }, [summary]);
+    const assignmentsByHours = React.useMemo(() => {
+        const indexedByHours: Record<number, Assignment[]> = {};
+        for (const assignment of activeAssignments) {
+            indexedByHours[assignment.hours] =
+                indexedByHours[assignment.hours] || [];
+            indexedByHours[assignment.hours].push(assignment);
+        }
+
+        for (const assignments of Object.values(indexedByHours)) {
+            assignments.sort((a, b) => {
+                const aName = `${a.applicant.last_name}, ${a.applicant.first_name}`;
+                const bName = `${b.applicant.last_name}, ${b.applicant.first_name}`;
+                return aName.localeCompare(bName);
+            });
+        }
+
+        const ret = Object.entries(indexedByHours);
+        // The list should be sorted so that the "default assignment" appears first
+        // and all other assignments are sorted numerically.
+        ret.sort(([_hours_a, assignments_a], [_hours_b, assignments_b]) => {
+            const hours_a = +_hours_a;
+            const hours_b = +_hours_b;
+
+            if (hours_a === position.hours_per_assignment) {
+                return 1;
+            }
+            if (hours_a > hours_b) {
+                return 1;
+            } else if (hours_a < hours_b) {
+                return -1;
+            }
+            return 0;
+        });
+        return ret;
+    }, [activeAssignments, position.hours_per_assignment]);
+
+    return (
+        <div className="position-row">
+            <PositionLabel position={position} summary={summary} />
+            <div className="position-row-body">
+                {assignmentsByHours.map(([_hours, assignments], i) => {
+                    const hours = +_hours;
+                    return (
+                        <div className="row-division" key={i}>
+                            <div className="row-division-header">
+                                {round(hours, 2)} hours
+                            </div>
+                            <div className="row-division-body">
+                                {assignments.map((assignment, i) => (
+                                    <ApplicantPill
+                                        applicant={assignment.applicant}
+                                        key={i}
+                                    />
+                                ))}
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+export function GroupedOverview() {
+    const positions = useSelector(positionsSelector);
+    const assignments = useSelector(assignmentsSelector);
+    const positionSummaries = React.useMemo(() => {
+        const assignmentsByPositionId: Record<number, Assignment[]> = {};
+        for (const assignment of assignments) {
+            assignmentsByPositionId[assignment.position.id] =
+                assignmentsByPositionId[assignment.position.id] || [];
+            assignmentsByPositionId[assignment.position.id].push(assignment);
+        }
+
+        const ret: Record<number, PositionSummary> = {};
+        for (const position of positions) {
+            const assignmentsForPosition =
+                assignmentsByPositionId[position.id] || [];
+            const activeAssignments = assignmentsForPosition.filter(
+                (assignment) =>
+                    ["accepted", "provisional", "pending"].includes(
+                        assignment.active_offer_status || ""
+                    )
+            );
+            const targetHours = round(
+                position.hours_per_assignment *
+                    (position.desired_num_assignments || 0),
+                2
+            );
+            const hoursAssigned = round(
+                sum(...activeAssignments.map((assignment) => assignment.hours)),
+                2
+            );
+            let filledStatus: "under" | "over" | "matched" = "under";
+            if (hoursAssigned - targetHours > 2) {
+                filledStatus = "over";
+            } else if (hoursAssigned - targetHours > -2) {
+                filledStatus = "matched";
+            }
+
+            ret[position.id] = {
+                assignments: assignmentsByPositionId[position.id] || [],
+                numActiveAssignments: activeAssignments.length,
+                hoursAssigned,
+                filledStatus,
+            };
+        }
+        return ret;
+    }, [positions, assignments]);
+
+    return (
+        <div className="assignments-summary">
+            {positions.map((position) => (
+                <PositionRow
+                    position={position}
+                    summary={positionSummaries[position.id]}
+                    key={position.id}
+                />
+            ))}
+        </div>
+    );
+}

--- a/frontend/src/views/admin/matching/index.tsx
+++ b/frontend/src/views/admin/matching/index.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { ContentArea } from "../../../components/layout";
+import { useSelector } from "react-redux";
+import { activeSessionSelector, fetchPostings } from "../../../api/actions";
+import { useThunkDispatch } from "../../../libs/thunk-dispatch";
+import { GroupedOverview } from "./grouped-overview";
+
+export function AdminMatchingView() {
+    const activeSession = useSelector(activeSessionSelector);
+    const dispatch = useThunkDispatch();
+
+    // We don't load postings by default, so we load them dynamically whenever
+    // we view this page.
+    React.useEffect(() => {
+        async function fetchResources() {
+            return await dispatch(fetchPostings());
+        }
+
+        if (activeSession) {
+            fetchResources();
+        }
+    }, [activeSession, dispatch]);
+
+    return (
+        <div className="page-body">
+            <ContentArea>
+                <h4>Assignments Summary</h4>
+                <GroupedOverview />
+            </ContentArea>
+        </div>
+    );
+}

--- a/frontend/src/views/admin/routes/index.tsx
+++ b/frontend/src/views/admin/routes/index.tsx
@@ -12,6 +12,7 @@ import { PostingOverview } from "../postings/overview";
 import { PostingDetails } from "../postings/posting-details";
 import { PostingPreview } from "../postings/posting-preview";
 import { AdminApplicationsView } from "../applications";
+import { AdminMatchingView } from "../matching";
 
 export function AdminRoutes() {
     return (
@@ -54,6 +55,9 @@ export function AdminRoutes() {
             </Route>
             <Route exact path="/applicants_and_matching/applications">
                 <AdminApplicationsView />
+            </Route>
+            <Route exact path="/applicants_and_matching/matching">
+                <AdminMatchingView />
             </Route>
             <Route exact path="/postings">
                 <Redirect to="/postings/overview" />


### PR DESCRIPTION
There is now a summary page in the "Matching" tab that shows a read-only summary of all the assignments.

This PR also
  * Adds the ability to edit a contract's start/end dates
  * Rounds DDAH hours to the nearest .01 hour (this prevents floating point errors with `.2+.2+.2+.2+.2 !== 1`)