### PR TITLE
Rejected offers

### DIFF
--- a/frontend/src/views/admin/matching/actions.ts
+++ b/frontend/src/views/admin/matching/actions.ts
@@ -245,12 +245,16 @@ export const matchesSelector = createSelector(
             // Override with official assignments
             for (const assignment of assignmentsByApplicantId[applicant.id] ||
                 []) {
-                matchesByPositionId[assignment.position.id] = {
-                    applicant: applicant,
-                    position: assignment.position,
-                    hoursAssigned: assignment.hours || 0,
-                    status: "assigned",
-                };
+                // Check if offer was rejected/withdrawn:
+                if (assignment.active_offer_status !== "rejected" &&
+                    assignment.active_offer_status !== "withdrawn") {
+                    matchesByPositionId[assignment.position.id] = {
+                        applicant: applicant,
+                        position: assignment.position,
+                        hoursAssigned: assignment.hours || 0,
+                        status: "assigned",
+                    };
+                }
             }
 
             ret = [...ret, ...Object.values(matchesByPositionId)];

--- a/frontend/src/views/admin/matching/actions.ts
+++ b/frontend/src/views/admin/matching/actions.ts
@@ -272,7 +272,8 @@ export const matchesSelector = createSelector(
  */
 function activeOfferStatusToStatus(active_offer_status: string | null) {
     switch (active_offer_status) {
-        case "rejected" || "withdrawn":
+        case "rejected":
+        case "withdrawn":
             return "unassignable";
         default:
             return "assigned";

--- a/frontend/src/views/admin/matching/actions.ts
+++ b/frontend/src/views/admin/matching/actions.ts
@@ -248,7 +248,10 @@ export const matchesSelector = createSelector(
                 let hours = assignment.hours || 0;
                 let status: MatchStatus = "assigned";
 
-                if (assignment.active_offer_status === "rejected" || assignment.active_offer_status === "withdrawn") {
+                if (
+                    assignment.active_offer_status === "rejected" ||
+                    assignment.active_offer_status === "withdrawn"
+                ) {
                     status = "unassignable";
                     hours = 0;
                 }
@@ -377,7 +380,7 @@ export const positionSummariesByIdSelector = createSelector(
                     "staged-assigned": [],
                     hidden: [],
                     starred: [],
-                    unassignable: []
+                    unassignable: [],
                 };
             }
 

--- a/frontend/src/views/admin/matching/actions.ts
+++ b/frontend/src/views/admin/matching/actions.ts
@@ -7,12 +7,7 @@ import {
     positionsSelector,
     applicantsSelector,
 } from "../../../api/actions";
-import {
-    Assignment,
-    Application,
-    Position,
-    RawAssignment,
-} from "../../../api/defs/types";
+import { Assignment, Application, Position } from "../../../api/defs/types";
 import {
     UPSERT_MATCH,
     BATCH_UPSERT_MATCHES,

--- a/frontend/src/views/admin/matching/applicant-view/grid/grid-item/dropdown.tsx
+++ b/frontend/src/views/admin/matching/applicant-view/grid/grid-item/dropdown.tsx
@@ -33,7 +33,7 @@ export function GridItemDropdown({
         match.status === "starred";
 
     const canBeHidden =
-        match.status !== "assigned" && match.status !== "hidden";
+        match.status !== "assigned" && match.status !== "unassignable" && match.status !== "hidden";
 
     const assignToPosition = React.useCallback(() => {
         dispatch(

--- a/frontend/src/views/admin/matching/applicant-view/grid/grid-item/dropdown.tsx
+++ b/frontend/src/views/admin/matching/applicant-view/grid/grid-item/dropdown.tsx
@@ -33,7 +33,9 @@ export function GridItemDropdown({
         match.status === "starred";
 
     const canBeHidden =
-        match.status !== "assigned" && match.status !== "unassignable" && match.status !== "hidden";
+        match.status !== "assigned" &&
+        match.status !== "unassignable" &&
+        match.status !== "hidden";
 
     const assignToPosition = React.useCallback(() => {
         dispatch(

--- a/frontend/src/views/admin/matching/applicant-view/grid/grid-view.tsx
+++ b/frontend/src/views/admin/matching/applicant-view/grid/grid-view.tsx
@@ -62,7 +62,7 @@ export function GridView({
                 return (
                     <GridSection
                         key={status}
-                        header={matchingStatusToString[status]}
+                        status={status}
                         applicantSummaries={
                             applicantSummariesByMatchStatus[status]
                         }
@@ -78,11 +78,11 @@ export function GridView({
  * A section/collection of grid items for a specified match status (e.g., applied, staged-assigned).
  */
 function GridSection({
-    header,
+    status,
     applicantSummaries,
     position,
 }: {
-    header: string;
+    status: MatchStatus;
     applicantSummaries: ApplicantSummary[];
     position: Position;
 }) {
@@ -94,15 +94,15 @@ function GridSection({
     return (
         <div className="grid-view-section">
             <h4>
-                {header}
-                {header === "Assigned" && (
+                {matchingStatusToString[status]}
+                {status === "assigned" && (
                     <FaLock
                         className="header-lock"
                         title="These assignments can only be changed through the Assignments &
             Positions > Assignments tab."
                     />
                 )}
-                {header === "Unassignable" && (
+                {status === "unassignable" && (
                     <FaLock
                         className="header-lock"
                         title="These applicants have an assignment for this position that was previously

--- a/frontend/src/views/admin/matching/applicant-view/grid/grid-view.tsx
+++ b/frontend/src/views/admin/matching/applicant-view/grid/grid-view.tsx
@@ -107,7 +107,7 @@ function GridSection({
                         className="header-lock"
                         title="These applicants have an assignment for this position that was previously
             rejected/withdrawn, and can only be changed through the Assignments & Positions > Assignments tab."
-                        />
+                    />
                 )}
             </h4>
             <div className="grid-view-list">

--- a/frontend/src/views/admin/matching/applicant-view/grid/grid-view.tsx
+++ b/frontend/src/views/admin/matching/applicant-view/grid/grid-view.tsx
@@ -26,6 +26,7 @@ export function GridView({
             starred: [],
             "staged-assigned": [],
             assigned: [],
+            unassignable: [],
             hidden: [],
         };
 
@@ -51,6 +52,7 @@ export function GridView({
         "staged-assigned",
         "starred",
         "applied",
+        "unassignable",
         "hidden",
     ];
 
@@ -99,6 +101,13 @@ function GridSection({
                         title="These assignments can only be changed through the Assignments &
             Positions > Assignments tab."
                     />
+                )}
+                {header === "Unassignable" && (
+                    <FaLock
+                        className="header-lock"
+                        title="These applicants have an assignment for this position that was previously
+            rejected/withdrawn, and can only be changed through the Assignments & Positions > Assignments tab."
+                        />
                 )}
             </h4>
             <div className="grid-view-list">

--- a/frontend/src/views/admin/matching/applicant-view/index.tsx
+++ b/frontend/src/views/admin/matching/applicant-view/index.tsx
@@ -13,6 +13,7 @@ export const matchingStatusToString: Record<MatchStatus, string> = {
     "staged-assigned": "Assigned (Staged)",
     applied: "Applied",
     starred: "Starred",
+    unassignable: "Unassignable",
     hidden: "Hidden",
 };
 

--- a/frontend/src/views/admin/matching/filters/filters.ts
+++ b/frontend/src/views/admin/matching/filters/filters.ts
@@ -68,6 +68,7 @@ export const filterMap: Record<
             { label: "Assigned (Staged)", value: "staged-assigned" },
             { label: "Starred", value: "starred" },
             { label: "Applied", value: "applied" },
+            { label: "Unassignable", value: "unassignable" },
             { label: "Hidden", value: "hidden" },
         ],
         hasOther: false,

--- a/frontend/src/views/admin/matching/filters/index.tsx
+++ b/frontend/src/views/admin/matching/filters/index.tsx
@@ -6,7 +6,7 @@ export const defaultFilterList: Record<FilterType, any[]> = {
     program: [],
     department: [],
     taPositionPref: [],
-    status: ["hidden"],
+    status: ["unassignable", "hidden"],
     hourFulfillment: [],
 };
 

--- a/frontend/src/views/admin/matching/index.tsx
+++ b/frontend/src/views/admin/matching/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { ContentArea } from "../../../components/layout";
 import { useSelector } from "react-redux";
 import { activeSessionSelector, fetchPostings } from "../../../api/actions";
 import { useThunkDispatch } from "../../../libs/thunk-dispatch";

--- a/frontend/src/views/admin/matching/reducers.ts
+++ b/frontend/src/views/admin/matching/reducers.ts
@@ -15,6 +15,7 @@ import {
     AppointmentGuaranteeStatus,
     ApplicantViewMode,
 } from "./types";
+
 export { matchingDataReducer };
 
 export interface MatchingDataState {

--- a/frontend/src/views/admin/matching/types.ts
+++ b/frontend/src/views/admin/matching/types.ts
@@ -12,6 +12,7 @@ export type RawMatch = {
     stagedHoursAssigned?: number;
     stagedAssigned?: boolean;
     starred?: boolean;
+    unassignable?: boolean;
     hidden?: boolean;
 };
 
@@ -52,5 +53,6 @@ export type MatchStatus =
     | "starred"
     | "staged-assigned"
     | "assigned"
+    | "unassignable"
     | "hidden";
 export type FillStatus = "empty" | "under" | "matched" | "over" | "n/a";


### PR DESCRIPTION
This pull request fixes the issue where rejected/withdrawn offers would count towards the total number of assigned hours for positions in matching data.

This fix also adds another category/match status ("unassignable") so that admins cannot re-assign these TAs via matching and instead need to do so via the Assignments tab. Unassignable applicants are hidden by default in the applicant list.