### PR TITLE
Switch to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,6 @@ jobs:
     - name: Clean up Docker
       run: docker-compose down
   production-build:
-    if: ${{ github.event.issue.push }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
@@ -58,7 +57,7 @@ jobs:
       if: ${{ failure() }}
       run: docker-compose logs
     - name: Deploy
-      if: ${{ success() }}
+      if: ${{ success() && github.event.issue.push }}
       uses: crazy-max/ghaction-github-pages@v3
       with:
         target_branch: gh-pages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,7 @@ jobs:
     - name: Clean up Docker
       run: docker-compose down
   production-build:
+    if: ${{ github.event.issue.push }}
     needs: [code-formatting, ruby-linting, unit-tests]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: TAPP CI
 
 on:
   push:
@@ -7,12 +7,78 @@ on:
     branches: [ "master" ]
 
 jobs:
-
-  build:
-
+  code-formatting:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Set up node
+      uses: actions/setup-node@v3
+    - name: Install npm packages
+      run: npm ci
+    - name: Run code formatting tests
+      run: ./tests/run-formatting-tests.sh
+  ruby-linting:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Build Docker backend
+      run: |
+        cp dev.env .env
+        docker-compose up --build -d backend
+        docker ps -a
+    - name: Run Ruby formatting tests
+      run: 
+        ./tests/run-ruby-linting-tests.sh
+    - name: Display Docker logs on failure
+      if: ${{ failure() }}
+      run: docker-compose logs
+    - name: Clean up Docker
+      run: docker-compose down
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Build Docker backend
+      run: |
+        cp dev.env .env
+        docker-compose up --build -d
+        docker ps -a
+        docker-compose run backend rake db:create
+        docker-compose run backend rake db:migrate
+        sleep 30
+    - name: Display Docker logs on failure
+      if: ${{ failure() }}
+      run: docker-compose logs
+    - name: Run unit tests
+      run: ./tests/run-unit-tests.sh
+    - name: Display Docker logs on failure
+      if: ${{ failure() }}
+      run: docker-compose logs
+    - name: Clean up Docker
+      run: docker-compose down
+  production-build:
+    needs: [code-formatting, ruby-linting, unit-tests]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Build Docker
+      run: |
+        cp dev.env .env
+        docker-compose up --build -d
+        docker ps -a
+        docker-compose run frontend npm run dev-build
+    - name: Display Docker logs on failure
+      if: ${{ failure() }}
+      run: docker-compose logs
+    - name: Deploy
+      if: ${{ success() }}
+      uses: crazy-max/ghaction-github-pages@v3
+      with:
+        target_branch: gh-pages
+        build_dir: frontend/build
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,6 @@ jobs:
       run: docker-compose down
   production-build:
     if: ${{ github.event.issue.push }}
-    needs: [code-formatting, unit-tests]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,24 +18,8 @@ jobs:
       run: npm ci
     - name: Run code formatting tests
       run: ./tests/run-formatting-tests.sh
-  ruby-linting:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v3
-    - name: Build Docker backend
-      run: |
-        cp dev.env .env
-        docker-compose up --build -d backend
-        docker ps -a
     - name: Run Ruby formatting tests
-      run: 
-        ./tests/run-ruby-linting-tests.sh
-    - name: Display Docker logs on failure
-      if: ${{ failure() }}
-      run: docker-compose logs
-    - name: Clean up Docker
-      run: docker-compose down
+      run: ./tests/run-ruby-linting-tests.sh
   unit-tests:
     runs-on: ubuntu-latest
     steps:
@@ -48,7 +32,6 @@ jobs:
         docker ps -a
         docker-compose run backend rake db:create
         docker-compose run backend rake db:migrate
-        sleep 30
     - name: Display Docker logs on failure
       if: ${{ failure() }}
       run: docker-compose logs
@@ -61,7 +44,7 @@ jobs:
       run: docker-compose down
   production-build:
     if: ${{ github.event.issue.push }}
-    needs: [code-formatting, ruby-linting, unit-tests]
+    needs: [code-formatting, unit-tests]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,10 +67,3 @@ matrix:
         - docker-compose logs
       after_script:
         - docker-compose down
-      deploy:
-        provider: pages
-        skip_cleanup: true
-        github_token: $GITHUB_PAGES_TOKEN
-        local_dir: frontend/build
-        on:
-          branch: master


### PR DESCRIPTION
This PR resolves #699.

Travis CI configuration has been ported over to GitHub Actions and covers all tests previously handled on Travis. Production deployment should also work, automatically pushing things to the gh-pages branch.